### PR TITLE
feat: define TypeScript types for rules, transactions, and decisions

### DIFF
--- a/backend/src/types/decision.types.ts
+++ b/backend/src/types/decision.types.ts
@@ -1,1 +1,22 @@
-// Decision types
+// Decision types — matches risk_logs and triggered_rules table schema
+
+export type Decision = 'ALLOW' | 'REVIEW' | 'BLOCK';
+
+// A single rule that triggered during evaluation
+export interface TriggeredRule {
+  rule_id: string;
+  rule_name: string;
+  rule_type: string;
+  weight_applied: number;
+  reason: string; // human-readable explanation e.g. "amount (15000) gt 10000"
+}
+
+// Full result of evaluating one transaction through the engine
+export interface EvaluationResult {
+  tx_id: string;
+  risk_score: number;
+  decision: Decision;
+  triggered_rules: TriggeredRule[];
+  evaluation_time: Date;
+  is_alert_generated: boolean;
+}

--- a/backend/src/types/rule.types.ts
+++ b/backend/src/types/rule.types.ts
@@ -1,1 +1,30 @@
-// Rule types
+// Rule types — matches fraud_rules table schema
+
+export type RuleType = 'threshold' | 'velocity' | 'temporal';
+
+export type Operator =
+  | 'gt'      // greater than        >
+  | 'lt'      // less than           <
+  | 'gte'     // greater or equal    >=
+  | 'lte'     // less or equal       <=
+  | 'eq'      // equal               ==
+  | 'neq'     // not equal           !=
+  | 'in'      // value in set        e.g. threshold_value: "US,UK,CA"
+  | 'not_in'  // value not in set
+  | 'range'   // between min and max e.g. threshold_value: "100-5000"
+  | 'regex';  // regex match for string fields
+
+export interface FraudRule {
+  rule_id: string;
+  rule_name: string;
+  rule_type: RuleType;
+  field_name: string;       // e.g. 'amount', 'location', 'hour_of_day', 'tx_count_1h'
+  operator: Operator;
+  threshold_value: string;  // stored as string in DB, parsed at evaluation time
+  weight: number;           // 1–100, contribution to risk score
+  priority: number;         // lower number = evaluated first
+  is_active: boolean;
+  created_by: string | null;
+  created_at: Date;
+  updated_at: Date;
+}

--- a/backend/src/types/transaction.types.ts
+++ b/backend/src/types/transaction.types.ts
@@ -1,1 +1,22 @@
-// Transaction types
+// Transaction types — matches transactions table schema
+
+export interface Transaction {
+  tx_id: string;
+  user_id: string;
+  amount: number;
+  location: string;
+  device_id: string;
+  transaction_time: Date;
+  is_simulation: boolean;
+  created_at: Date;
+}
+
+// Input shape for incoming API requests (before tx_id and created_at are assigned)
+export interface TransactionInput {
+  user_id: string;
+  amount: number;
+  location: string;
+  device_id: string;
+  transaction_time?: string; // ISO string, defaults to now if not provided
+  is_simulation?: boolean;   // defaults to false
+}


### PR DESCRIPTION
Closes #10

## Changes
- rule.types.ts — FraudRule, RuleType, Operator
- transaction.types.ts — Transaction, TransactionInput
- decision.types.ts — EvaluationResult, TriggeredRule, Decision

## Notes
- All types match the DB schema from the PDF diagram
- No `any` types used
- All types are exported and ready to be imported by engine files