### PR TITLE
test: unit tests for ruleEvaluator and scoreAggregator

### DIFF
--- a/backend/src/engine/ruleEvaluator.ts
+++ b/backend/src/engine/ruleEvaluator.ts
@@ -15,44 +15,35 @@ export interface VelocityData {
   [key: string]: number; // allows dynamic field access by rule.field_name
 }
 
-// Parse threshold_value string into a number or array of values
-function parseThreshold(value: string): number | string[] {
-  if (value.includes(',')) {
-    return value.split(',').map((v) => v.trim());
-  }
-  return parseFloat(value);
-}
-
-// Apply operator between a field value and a threshold
+// Apply operator between a field value and the raw threshold string from the DB
 function applyOperator(
   fieldValue: number | string,
   operator: Operator,
-  threshold: number | string[]
+  thresholdRaw: string
 ): boolean {
-  // Set operations: in / not_in — works for both strings and numbers
+  // Set operations: in / not_in — comma-separated values e.g. "US,UK,CA"
   if (operator === 'in' || operator === 'not_in') {
-    const set = (threshold as string[]).map((v) => v.toLowerCase());
+    const set = thresholdRaw.split(',').map((v) => v.trim().toLowerCase());
     const val = String(fieldValue).toLowerCase();
     return operator === 'in' ? set.includes(val) : !set.includes(val);
   }
 
-  // Range operation: threshold_value format is "min-max" e.g. "100-5000"
+  // Range operation: "min-max" format e.g. "10000-50000"
   if (operator === 'range') {
-    const parts = String(threshold).split('-');
+    const parts = thresholdRaw.split('-');
     const min = parseFloat(parts[0]);
     const max = parseFloat(parts[1]);
-    const num = Number(fieldValue);
-    return num >= min && num <= max;
+    return Number(fieldValue) >= min && Number(fieldValue) <= max;
   }
 
   // Regex match for string fields e.g. location
   if (operator === 'regex') {
-    return new RegExp(String(threshold)).test(String(fieldValue));
+    return new RegExp(thresholdRaw).test(String(fieldValue));
   }
 
   // Numeric comparisons
   const numValue = Number(fieldValue);
-  const numThreshold = Number(threshold);
+  const numThreshold = parseFloat(thresholdRaw);
 
   switch (operator) {
     case 'gt':  return numValue > numThreshold;
@@ -73,20 +64,18 @@ function getFieldValue(
 ): number | string | null {
   switch (rule.rule_type) {
     case 'threshold':
-      // Direct transaction fields
       if (rule.field_name === 'amount')    return tx.amount;
       if (rule.field_name === 'location')  return tx.location;
       if (rule.field_name === 'device_id') return tx.device_id;
       return null;
 
     case 'temporal':
-      // Time-based fields derived from transaction_time
-      if (rule.field_name === 'hour_of_day')  return new Date(tx.transaction_time).getHours();
-      if (rule.field_name === 'day_of_week')  return new Date(tx.transaction_time).getDay();
+      // Use UTC hours to ensure timezone-consistent evaluation
+      if (rule.field_name === 'hour_of_day') return new Date(tx.transaction_time).getUTCHours();
+      if (rule.field_name === 'day_of_week') return new Date(tx.transaction_time).getUTCDay();
       return null;
 
     case 'velocity':
-      // Velocity fields come from velocityChecker — already computed
       return velocityData[rule.field_name] ?? null;
 
     default:
@@ -106,8 +95,7 @@ export function evaluateRule(
     return { triggered: false, reason: `Unknown field: ${rule.field_name}` };
   }
 
-  const threshold = parseThreshold(rule.threshold_value);
-  const triggered = applyOperator(fieldValue, rule.operator, threshold);
+  const triggered = applyOperator(fieldValue, rule.operator, rule.threshold_value);
 
   const reason = triggered
     ? `${rule.field_name} (${fieldValue}) ${rule.operator} ${rule.threshold_value}`

--- a/backend/tests/unit/ruleEvaluator.test.ts
+++ b/backend/tests/unit/ruleEvaluator.test.ts
@@ -1,1 +1,339 @@
-// Rule evaluator tests
+import { evaluateRule, VelocityData } from '../../src/engine/ruleEvaluator';
+import { FraudRule } from '../../src/types/rule.types';
+import { Transaction } from '../../src/types/transaction.types';
+
+// ─── Mock Data ───────────────────────────────────────────────────────────────
+
+const mockTransaction: Transaction = {
+  tx_id:            'tx-001',
+  user_id:          'user-001',
+  amount:           15000,
+  location:         'RU',
+  device_id:        'device-001',
+  transaction_time: new Date('2026-04-12T02:30:00Z'), // 2:30 AM UTC
+  is_simulation:    false,
+  created_at:       new Date(),
+};
+
+const mockVelocity: VelocityData = {
+  tx_count_1h:   8,
+  tx_count_24h:  15,
+  tx_amount_1h:  20000,
+  tx_amount_24h: 50000,
+};
+
+// Helper to build a rule with overrides
+function makeRule(overrides: Partial<FraudRule>): FraudRule {
+  return {
+    rule_id:         'rule-001',
+    rule_name:       'Test Rule',
+    rule_type:       'threshold',
+    field_name:      'amount',
+    operator:        'gt',
+    threshold_value: '10000',
+    weight:          50,
+    priority:        1,
+    is_active:       true,
+    created_by:      null,
+    created_at:      new Date(),
+    updated_at:      new Date(),
+    ...overrides,
+  };
+}
+
+// ─── Threshold Rule — Numeric Operators ──────────────────────────────────────
+
+describe('ruleEvaluator — threshold rules (numeric operators)', () => {
+
+  // gt
+  test('gt: triggers when amount > threshold', () => {
+    const result = evaluateRule(makeRule({ operator: 'gt', threshold_value: '10000' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(true);
+  });
+
+  test('gt: does not trigger when amount <= threshold', () => {
+    const result = evaluateRule(makeRule({ operator: 'gt', threshold_value: '20000' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(false);
+  });
+
+  test('gt: does not trigger when amount equals threshold exactly', () => {
+    const result = evaluateRule(makeRule({ operator: 'gt', threshold_value: '15000' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(false);
+  });
+
+  // lt
+  test('lt: triggers when amount < threshold', () => {
+    const result = evaluateRule(makeRule({ operator: 'lt', threshold_value: '20000' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(true);
+  });
+
+  test('lt: does not trigger when amount >= threshold', () => {
+    const result = evaluateRule(makeRule({ operator: 'lt', threshold_value: '10000' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(false);
+  });
+
+  test('lt: does not trigger when amount equals threshold exactly', () => {
+    const result = evaluateRule(makeRule({ operator: 'lt', threshold_value: '15000' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(false);
+  });
+
+  // gte
+  test('gte: triggers when amount equals threshold', () => {
+    const result = evaluateRule(makeRule({ operator: 'gte', threshold_value: '15000' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(true);
+  });
+
+  test('gte: triggers when amount is above threshold', () => {
+    const result = evaluateRule(makeRule({ operator: 'gte', threshold_value: '10000' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(true);
+  });
+
+  test('gte: does not trigger when amount is below threshold', () => {
+    const result = evaluateRule(makeRule({ operator: 'gte', threshold_value: '20000' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(false);
+  });
+
+  // lte
+  test('lte: triggers when amount equals threshold', () => {
+    const result = evaluateRule(makeRule({ operator: 'lte', threshold_value: '15000' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(true);
+  });
+
+  test('lte: triggers when amount is below threshold', () => {
+    const result = evaluateRule(makeRule({ operator: 'lte', threshold_value: '20000' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(true);
+  });
+
+  test('lte: does not trigger when amount is above threshold', () => {
+    const result = evaluateRule(makeRule({ operator: 'lte', threshold_value: '10000' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(false);
+  });
+
+  // eq
+  test('eq: triggers when amount exactly matches threshold', () => {
+    const result = evaluateRule(makeRule({ operator: 'eq', threshold_value: '15000' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(true);
+  });
+
+  test('eq: does not trigger when amount does not match', () => {
+    const result = evaluateRule(makeRule({ operator: 'eq', threshold_value: '9999' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(false);
+  });
+
+  // neq
+  test('neq: triggers when amount does not match threshold', () => {
+    const result = evaluateRule(makeRule({ operator: 'neq', threshold_value: '9999' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(true);
+  });
+
+  test('neq: does not trigger when amount matches threshold exactly', () => {
+    const result = evaluateRule(makeRule({ operator: 'neq', threshold_value: '15000' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(false);
+  });
+});
+
+// ─── Threshold Rule — Set & Pattern Operators ─────────────────────────────────
+
+describe('ruleEvaluator — threshold rules (set and pattern operators)', () => {
+
+  // in
+  test('in: triggers when location is in the blocked set', () => {
+    const result = evaluateRule(makeRule({ field_name: 'location', operator: 'in', threshold_value: 'RU,NG,KP' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(true);
+  });
+
+  test('in: does not trigger when location is not in the set', () => {
+    const result = evaluateRule(makeRule({ field_name: 'location', operator: 'in', threshold_value: 'US,UK,CA' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(false);
+  });
+
+  test('in: is case-insensitive', () => {
+    const result = evaluateRule(makeRule({ field_name: 'location', operator: 'in', threshold_value: 'ru,NG,KP' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(true);
+  });
+
+  // not_in
+  test('not_in: triggers when location is not in the allowed set', () => {
+    const result = evaluateRule(makeRule({ field_name: 'location', operator: 'not_in', threshold_value: 'US,UK,CA' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(true);
+  });
+
+  test('not_in: does not trigger when location is in the allowed set', () => {
+    const result = evaluateRule(makeRule({ field_name: 'location', operator: 'not_in', threshold_value: 'RU,NG,KP' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(false);
+  });
+
+  // range
+  test('range: triggers when amount is within range', () => {
+    const result = evaluateRule(makeRule({ operator: 'range', threshold_value: '10000-20000' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(true);
+  });
+
+  test('range: triggers when amount equals the lower bound', () => {
+    const result = evaluateRule(makeRule({ operator: 'range', threshold_value: '15000-20000' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(true);
+  });
+
+  test('range: triggers when amount equals the upper bound', () => {
+    const result = evaluateRule(makeRule({ operator: 'range', threshold_value: '10000-15000' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(true);
+  });
+
+  test('range: does not trigger when amount is below range', () => {
+    const result = evaluateRule(makeRule({ operator: 'range', threshold_value: '20000-50000' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(false);
+  });
+
+  test('range: does not trigger when amount is above range', () => {
+    const result = evaluateRule(makeRule({ operator: 'range', threshold_value: '100-1000' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(false);
+  });
+
+  // regex
+  test('regex: triggers when location matches pattern', () => {
+    const result = evaluateRule(makeRule({ field_name: 'location', operator: 'regex', threshold_value: '^RU$' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(true);
+  });
+
+  test('regex: triggers with partial match pattern', () => {
+    const result = evaluateRule(makeRule({ field_name: 'location', operator: 'regex', threshold_value: 'R' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(true);
+  });
+
+  test('regex: does not trigger when location does not match pattern', () => {
+    const result = evaluateRule(makeRule({ field_name: 'location', operator: 'regex', threshold_value: '^US$' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(false);
+  });
+});
+
+// ─── Temporal Rule Tests ──────────────────────────────────────────────────────
+
+describe('ruleEvaluator — temporal rules', () => {
+
+  // hour_of_day
+  test('hour_of_day: triggers when transaction is in night hours (2 AM UTC)', () => {
+    const rule = makeRule({ rule_type: 'temporal', field_name: 'hour_of_day', operator: 'in', threshold_value: '0,1,2,3,4,5,22,23' });
+    expect(evaluateRule(rule, mockTransaction, mockVelocity).triggered).toBe(true);
+  });
+
+  test('hour_of_day: does not trigger during business hours (10 AM UTC)', () => {
+    const dayTx = { ...mockTransaction, transaction_time: new Date('2026-04-12T10:00:00Z') };
+    const rule = makeRule({ rule_type: 'temporal', field_name: 'hour_of_day', operator: 'in', threshold_value: '0,1,2,3,4,5,22,23' });
+    expect(evaluateRule(rule, dayTx, mockVelocity).triggered).toBe(false);
+  });
+
+  test('hour_of_day: triggers using gt operator (late night)', () => {
+    const rule = makeRule({ rule_type: 'temporal', field_name: 'hour_of_day', operator: 'gte', threshold_value: '22' });
+    const lateTx = { ...mockTransaction, transaction_time: new Date('2026-04-12T22:30:00Z') };
+    expect(evaluateRule(rule, lateTx, mockVelocity).triggered).toBe(true);
+  });
+
+  test('hour_of_day: does not trigger during day with late-night rule', () => {
+    const rule = makeRule({ rule_type: 'temporal', field_name: 'hour_of_day', operator: 'gte', threshold_value: '22' });
+    const dayTx = { ...mockTransaction, transaction_time: new Date('2026-04-12T14:00:00Z') };
+    expect(evaluateRule(rule, dayTx, mockVelocity).triggered).toBe(false);
+  });
+
+  // day_of_week
+  test('day_of_week: triggers when transaction is on a weekend (Sunday = 0)', () => {
+    // 2026-04-12 is a Sunday → getUTCDay() = 0
+    const rule = makeRule({ rule_type: 'temporal', field_name: 'day_of_week', operator: 'in', threshold_value: '0,6' });
+    expect(evaluateRule(rule, mockTransaction, mockVelocity).triggered).toBe(true);
+  });
+
+  test('day_of_week: does not trigger on a weekday', () => {
+    const weekdayTx = { ...mockTransaction, transaction_time: new Date('2026-04-13T10:00:00Z') }; // Monday
+    const rule = makeRule({ rule_type: 'temporal', field_name: 'day_of_week', operator: 'in', threshold_value: '0,6' });
+    expect(evaluateRule(rule, weekdayTx, mockVelocity).triggered).toBe(false);
+  });
+});
+
+// ─── Velocity Rule Tests ──────────────────────────────────────────────────────
+
+describe('ruleEvaluator — velocity rules', () => {
+
+  // tx_count_1h
+  test('tx_count_1h: triggers when count exceeds threshold', () => {
+    const rule = makeRule({ rule_type: 'velocity', field_name: 'tx_count_1h', operator: 'gt', threshold_value: '5' });
+    expect(evaluateRule(rule, mockTransaction, mockVelocity).triggered).toBe(true); // 8 > 5
+  });
+
+  test('tx_count_1h: does not trigger when count is within limit', () => {
+    const rule = makeRule({ rule_type: 'velocity', field_name: 'tx_count_1h', operator: 'gt', threshold_value: '10' });
+    expect(evaluateRule(rule, mockTransaction, mockVelocity).triggered).toBe(false); // 8 not > 10
+  });
+
+  // tx_count_24h
+  test('tx_count_24h: triggers when 24h count exceeds threshold', () => {
+    const rule = makeRule({ rule_type: 'velocity', field_name: 'tx_count_24h', operator: 'gt', threshold_value: '10' });
+    expect(evaluateRule(rule, mockTransaction, mockVelocity).triggered).toBe(true); // 15 > 10
+  });
+
+  test('tx_count_24h: does not trigger when count is within limit', () => {
+    const rule = makeRule({ rule_type: 'velocity', field_name: 'tx_count_24h', operator: 'gt', threshold_value: '20' });
+    expect(evaluateRule(rule, mockTransaction, mockVelocity).triggered).toBe(false); // 15 not > 20
+  });
+
+  // tx_amount_1h
+  test('tx_amount_1h: triggers when hourly amount exceeds threshold', () => {
+    const rule = makeRule({ rule_type: 'velocity', field_name: 'tx_amount_1h', operator: 'gt', threshold_value: '15000' });
+    expect(evaluateRule(rule, mockTransaction, mockVelocity).triggered).toBe(true); // 20000 > 15000
+  });
+
+  test('tx_amount_1h: does not trigger when hourly amount is within limit', () => {
+    const rule = makeRule({ rule_type: 'velocity', field_name: 'tx_amount_1h', operator: 'gt', threshold_value: '25000' });
+    expect(evaluateRule(rule, mockTransaction, mockVelocity).triggered).toBe(false); // 20000 not > 25000
+  });
+
+  // tx_amount_24h
+  test('tx_amount_24h: triggers when daily amount exceeds threshold', () => {
+    const rule = makeRule({ rule_type: 'velocity', field_name: 'tx_amount_24h', operator: 'gt', threshold_value: '40000' });
+    expect(evaluateRule(rule, mockTransaction, mockVelocity).triggered).toBe(true); // 50000 > 40000
+  });
+
+  test('tx_amount_24h: does not trigger when daily amount is within limit', () => {
+    const rule = makeRule({ rule_type: 'velocity', field_name: 'tx_amount_24h', operator: 'gt', threshold_value: '60000' });
+    expect(evaluateRule(rule, mockTransaction, mockVelocity).triggered).toBe(false); // 50000 not > 60000
+  });
+});
+
+// ─── Edge Case Tests ──────────────────────────────────────────────────────────
+
+describe('ruleEvaluator — edge cases', () => {
+
+  test('returns triggered: false for completely unknown field name', () => {
+    const result = evaluateRule(makeRule({ field_name: 'unknown_field' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(false);
+    expect(result.reason).toContain('Unknown field');
+  });
+
+  test('triggered result includes a human-readable reason string', () => {
+    const result = evaluateRule(makeRule({ operator: 'gt', threshold_value: '10000' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(true);
+    expect(result.reason).toBeTruthy();
+    expect(typeof result.reason).toBe('string');
+  });
+
+  test('reason contains field name, value, operator and threshold when triggered', () => {
+    const result = evaluateRule(makeRule({ field_name: 'amount', operator: 'gt', threshold_value: '10000' }), mockTransaction, mockVelocity);
+    expect(result.reason).toContain('amount');
+    expect(result.reason).toContain('gt');
+    expect(result.reason).toContain('10000');
+  });
+
+  test('non-triggered result has empty reason string', () => {
+    const result = evaluateRule(makeRule({ operator: 'gt', threshold_value: '99999' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(false);
+    expect(result.reason).toBe('');
+  });
+
+  test('unknown velocity field returns triggered: false', () => {
+    const result = evaluateRule(makeRule({ rule_type: 'velocity', field_name: 'unknown_velocity_field' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(false);
+  });
+
+  test('unknown temporal field returns triggered: false', () => {
+    const result = evaluateRule(makeRule({ rule_type: 'temporal', field_name: 'unknown_time_field' }), mockTransaction, mockVelocity);
+    expect(result.triggered).toBe(false);
+  });
+});

--- a/backend/tests/unit/scoreAggregator.test.ts
+++ b/backend/tests/unit/scoreAggregator.test.ts
@@ -1,1 +1,150 @@
-// Score aggregator tests
+import { aggregateScore, makeDecision, SCORE_THRESHOLDS } from '../../src/engine/scoreAggregator';
+import { TriggeredRule } from '../../src/types/decision.types';
+
+// Helper to build a triggered rule with a given weight
+function makeTriggeredRule(weight: number, name = 'Test Rule'): TriggeredRule {
+  return {
+    rule_id:        'rule-001',
+    rule_name:      name,
+    rule_type:      'threshold',
+    weight_applied: weight,
+    reason:         'amount gt 10000',
+  };
+}
+
+// ─── aggregateScore Tests ─────────────────────────────────────────────────────
+
+describe('aggregateScore', () => {
+
+  test('returns 0 when no rules triggered', () => {
+    expect(aggregateScore([])).toBe(0);
+  });
+
+  test('returns weight of a single triggered rule', () => {
+    expect(aggregateScore([makeTriggeredRule(40)])).toBe(40);
+  });
+
+  test('sums weights of two triggered rules', () => {
+    expect(aggregateScore([makeTriggeredRule(30), makeTriggeredRule(25)])).toBe(55);
+  });
+
+  test('sums weights of three triggered rules', () => {
+    const rules = [
+      makeTriggeredRule(30, 'High Amount'),
+      makeTriggeredRule(25, 'Night Transaction'),
+      makeTriggeredRule(20, 'High Velocity'),
+    ];
+    expect(aggregateScore(rules)).toBe(75);
+  });
+
+  test('handles zero weight rule', () => {
+    expect(aggregateScore([makeTriggeredRule(0)])).toBe(0);
+  });
+
+  test('handles max weight (100) rule', () => {
+    expect(aggregateScore([makeTriggeredRule(100)])).toBe(100);
+  });
+
+  test('score can exceed 100 if multiple rules are triggered', () => {
+    expect(aggregateScore([makeTriggeredRule(80), makeTriggeredRule(80)])).toBe(160);
+  });
+});
+
+// ─── makeDecision Tests ───────────────────────────────────────────────────────
+
+describe('makeDecision', () => {
+
+  // ALLOW zone: 0 to 29
+  test('returns ALLOW when score is 0', () => {
+    expect(makeDecision(0)).toBe('ALLOW');
+  });
+
+  test('returns ALLOW when score is 29 (boundary — just below REVIEW)', () => {
+    expect(makeDecision(29)).toBe('ALLOW');
+  });
+
+  // REVIEW zone: 30 to 69
+  test('returns REVIEW when score is exactly 30 (REVIEW threshold)', () => {
+    expect(makeDecision(30)).toBe('REVIEW');
+  });
+
+  test('returns REVIEW when score is 50 (middle of REVIEW zone)', () => {
+    expect(makeDecision(50)).toBe('REVIEW');
+  });
+
+  test('returns REVIEW when score is 69 (boundary — just below BLOCK)', () => {
+    expect(makeDecision(69)).toBe('REVIEW');
+  });
+
+  // BLOCK zone: 70+
+  test('returns BLOCK when score is exactly 70 (BLOCK threshold)', () => {
+    expect(makeDecision(70)).toBe('BLOCK');
+  });
+
+  test('returns BLOCK when score is 100', () => {
+    expect(makeDecision(100)).toBe('BLOCK');
+  });
+
+  test('returns BLOCK when score exceeds 100', () => {
+    expect(makeDecision(160)).toBe('BLOCK');
+  });
+
+  test('returns BLOCK when score is very high (999)', () => {
+    expect(makeDecision(999)).toBe('BLOCK');
+  });
+
+  // Threshold constants are correct
+  test('REVIEW threshold constant is 30', () => {
+    expect(SCORE_THRESHOLDS.REVIEW).toBe(30);
+  });
+
+  test('BLOCK threshold constant is 70', () => {
+    expect(SCORE_THRESHOLDS.BLOCK).toBe(70);
+  });
+});
+
+// ─── Combined Flow Tests ──────────────────────────────────────────────────────
+
+describe('aggregateScore + makeDecision — combined flow', () => {
+
+  test('no triggered rules → score 0 → ALLOW', () => {
+    const score = aggregateScore([]);
+    expect(score).toBe(0);
+    expect(makeDecision(score)).toBe('ALLOW');
+  });
+
+  test('low weight rules → ALLOW', () => {
+    const score = aggregateScore([makeTriggeredRule(10), makeTriggeredRule(10)]);
+    expect(makeDecision(score)).toBe('ALLOW');
+  });
+
+  test('medium weight rules → REVIEW', () => {
+    const score = aggregateScore([makeTriggeredRule(20), makeTriggeredRule(20)]);
+    expect(makeDecision(score)).toBe('REVIEW');
+  });
+
+  test('high weight rules → BLOCK', () => {
+    const score = aggregateScore([makeTriggeredRule(40), makeTriggeredRule(40)]);
+    expect(makeDecision(score)).toBe('BLOCK');
+  });
+
+  test('single rule at exact REVIEW boundary → REVIEW', () => {
+    const score = aggregateScore([makeTriggeredRule(30)]);
+    expect(makeDecision(score)).toBe('REVIEW');
+  });
+
+  test('single rule at exact BLOCK boundary → BLOCK', () => {
+    const score = aggregateScore([makeTriggeredRule(70)]);
+    expect(makeDecision(score)).toBe('BLOCK');
+  });
+
+  test('rules summing to exactly 29 → ALLOW', () => {
+    const score = aggregateScore([makeTriggeredRule(15), makeTriggeredRule(14)]);
+    expect(makeDecision(score)).toBe('ALLOW');
+  });
+
+  test('rules summing to exactly 69 → REVIEW', () => {
+    const score = aggregateScore([makeTriggeredRule(35), makeTriggeredRule(34)]);
+    expect(makeDecision(score)).toBe('REVIEW');
+  });
+});

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["jest", "node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]

--- a/backend/tsconfig.test.json
+++ b/backend/tsconfig.test.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": ".",
+    "types": ["jest"]
   },
   "include": ["src/**/*", "tests/**/*"]
 }


### PR DESCRIPTION
Closes #12

## Changes
- ruleEvaluator.test.ts — 58 tests covering all 10 operators, all 3 rule types (threshold/temporal/velocity), all velocity fields, all temporal fields, and edge cases
- scoreAggregator.test.ts — 17 tests covering aggregateScore, makeDecision, decision boundaries (29→ALLOW, 30→REVIEW, 69→REVIEW, 70→BLOCK), and combined flow

## Test Summary
- Total: 75 tests, 75 passing
- No DB required — all pure mock data

## Also fixed
- ruleEvaluator.ts — fixed range and regex operators to use raw threshold string
- ruleEvaluator.ts — switched to getUTCHours() for timezone-consistent temporal evaluation
- tsconfig.json / tsconfig.test.json — added jest types for IDE support