### PR TITLE
feat: implement ruleLoader and velocityChecker

### DIFF
--- a/backend/src/engine/ruleLoader.ts
+++ b/backend/src/engine/ruleLoader.ts
@@ -1,1 +1,25 @@
-// Rule loader implementation
+import pool from '../db/client';
+import { FraudRule } from '../types/rule.types';
+
+// Load all active fraud rules from DB, sorted by priority (lowest = evaluated first)
+export async function loadActiveRules(): Promise<FraudRule[]> {
+  const result = await pool.query<FraudRule>(
+    `SELECT
+       rule_id,
+       rule_name,
+       rule_type,
+       field_name,
+       operator,
+       threshold_value,
+       weight,
+       priority,
+       is_active,
+       created_by,
+       created_at,
+       updated_at
+     FROM fraud_rules
+     WHERE is_active = true
+     ORDER BY priority ASC`
+  );
+  return result.rows;
+}

--- a/backend/src/engine/velocityChecker.ts
+++ b/backend/src/engine/velocityChecker.ts
@@ -1,1 +1,45 @@
-// Velocity checker implementation
+import pool from '../db/client';
+import { VelocityData } from './ruleEvaluator';
+
+// Query historical transactions for a user within time windows
+// transactionTime is the current transaction's time — used as reference point
+export async function getVelocityData(
+  userId: string,
+  transactionTime: Date
+): Promise<VelocityData> {
+  const oneHourAgo       = new Date(transactionTime.getTime() - 60 * 60 * 1000);
+  const twentyFourHoursAgo = new Date(transactionTime.getTime() - 24 * 60 * 60 * 1000);
+
+  // Query for last 1 hour
+  const result1h = await pool.query<{ count: string; total: string }>(
+    `SELECT
+       COUNT(*)                    AS count,
+       COALESCE(SUM(amount), 0)   AS total
+     FROM transactions
+     WHERE user_id          = $1
+       AND transaction_time >= $2
+       AND transaction_time <  $3
+       AND is_simulation    = false`,
+    [userId, oneHourAgo, transactionTime]
+  );
+
+  // Query for last 24 hours
+  const result24h = await pool.query<{ count: string; total: string }>(
+    `SELECT
+       COUNT(*)                    AS count,
+       COALESCE(SUM(amount), 0)   AS total
+     FROM transactions
+     WHERE user_id          = $1
+       AND transaction_time >= $2
+       AND transaction_time <  $3
+       AND is_simulation    = false`,
+    [userId, twentyFourHoursAgo, transactionTime]
+  );
+
+  return {
+    tx_count_1h:   parseInt(result1h.rows[0].count,  10),
+    tx_amount_1h:  parseFloat(result1h.rows[0].total),
+    tx_count_24h:  parseInt(result24h.rows[0].count, 10),
+    tx_amount_24h: parseFloat(result24h.rows[0].total),
+  };
+}


### PR DESCRIPTION
Closes #13

## Changes
- ruleLoader.ts — queries fraud_rules table, returns FraudRule[] sorted by priority ASC, only active rules
- velocityChecker.ts — queries transactions table for a user's recent activity, returns tx_count_1h, tx_count_24h, tx_amount_1h, tx_amount_24h using the current transaction time as reference point, excludes simulation transactions

## Notes
- Both modules import from db/client — DB dependent
- Both are fully mockable in unit tests via jest.mock()
- velocityChecker excludes is_simulation = true transactions to avoid simulation data polluting real velocity counts