### PR TITLE
feat: implement decisionEngine orchestrator with idempotency handling

### DIFF
--- a/backend/src/engine/decisionEngine.ts
+++ b/backend/src/engine/decisionEngine.ts
@@ -1,1 +1,69 @@
-// Decision engine implementation
+import pool from '../db/client';
+import { FraudRule } from '../types/rule.types';
+import { Transaction } from '../types/transaction.types';
+import { EvaluationResult, TriggeredRule } from '../types/decision.types';
+import { evaluateRule } from './ruleEvaluator';
+import { getVelocityData } from './velocityChecker';
+import { aggregateScore, makeDecision } from './scoreAggregator';
+import { generateExplanation, ExplainableOutput } from './explainabilityGenerator';
+
+const ALERT_SCORE_THRESHOLD = 70; // same as BLOCK threshold
+
+// Check if this transaction has already been evaluated (idempotency)
+export async function isAlreadyEvaluated(txId: string): Promise<boolean> {
+  const result = await pool.query(
+    `SELECT 1 FROM risk_logs WHERE tx_id = $1 LIMIT 1`,
+    [txId]
+  );
+  return result.rowCount !== null && result.rowCount > 0;
+}
+
+// Main orchestrator — runs the full fraud evaluation pipeline for one transaction
+export async function runEvaluation(
+  tx: Transaction,
+  rules: FraudRule[]
+): Promise<ExplainableOutput> {
+
+  // Step 1 — Idempotency check: don't re-evaluate the same transaction
+  const alreadyDone = await isAlreadyEvaluated(tx.tx_id);
+  if (alreadyDone) {
+    throw new Error(`Transaction ${tx.tx_id} has already been evaluated`);
+  }
+
+  // Step 2 — Get velocity data for this user (DB query)
+  const velocityData = await getVelocityData(tx.user_id, new Date(tx.transaction_time));
+
+  // Step 3 — Evaluate each rule in priority order
+  const triggeredRules: TriggeredRule[] = [];
+
+  for (const rule of rules) {
+    const result = evaluateRule(rule, tx, velocityData);
+    if (result.triggered) {
+      triggeredRules.push({
+        rule_id:       rule.rule_id,
+        rule_name:     rule.rule_name,
+        rule_type:     rule.rule_type,
+        weight_applied: rule.weight,
+        reason:        result.reason,
+      });
+    }
+  }
+
+  // Step 4 — Aggregate score and make decision
+  const risk_score        = aggregateScore(triggeredRules);
+  const decision          = makeDecision(risk_score);
+  const is_alert_generated = risk_score >= ALERT_SCORE_THRESHOLD;
+
+  // Step 5 — Build evaluation result
+  const evaluationResult: EvaluationResult = {
+    tx_id:            tx.tx_id,
+    risk_score,
+    decision,
+    triggered_rules:  triggeredRules,
+    evaluation_time:  new Date(),
+    is_alert_generated,
+  };
+
+  // Step 6 — Return explainable output
+  return generateExplanation(evaluationResult);
+}

--- a/backend/tests/unit/decisionEngine.test.ts
+++ b/backend/tests/unit/decisionEngine.test.ts
@@ -1,1 +1,258 @@
-// Decision engine tests
+// Mock DB and engine dependencies BEFORE any imports
+jest.mock('../../src/db/client', () => ({ query: jest.fn() }));
+jest.mock('../../src/engine/velocityChecker');
+
+import pool from '../../src/db/client';
+import { getVelocityData } from '../../src/engine/velocityChecker';
+import { runEvaluation, isAlreadyEvaluated } from '../../src/engine/decisionEngine';
+import { FraudRule } from '../../src/types/rule.types';
+import { Transaction } from '../../src/types/transaction.types';
+import { VelocityData } from '../../src/engine/ruleEvaluator';
+
+const mockPool          = pool as jest.Mocked<typeof pool>;
+const mockGetVelocity   = getVelocityData as jest.MockedFunction<typeof getVelocityData>;
+
+// ─── Mock Data ────────────────────────────────────────────────────────────────
+
+const mockTransaction: Transaction = {
+  tx_id:            'tx-001',
+  user_id:          'user-001',
+  amount:           15000,
+  location:         'RU',
+  device_id:        'device-001',
+  transaction_time: new Date('2026-04-12T02:30:00Z'),
+  is_simulation:    false,
+  created_at:       new Date(),
+};
+
+const mockVelocity: VelocityData = {
+  tx_count_1h:   8,
+  tx_count_24h:  15,
+  tx_amount_1h:  20000,
+  tx_amount_24h: 50000,
+};
+
+const highAmountRule: FraudRule = {
+  rule_id:         'rule-001',
+  rule_name:       'High Amount',
+  rule_type:       'threshold',
+  field_name:      'amount',
+  operator:        'gt',
+  threshold_value: '10000',
+  weight:          50,
+  priority:        1,
+  is_active:       true,
+  created_by:      null,
+  created_at:      new Date(),
+  updated_at:      new Date(),
+};
+
+const velocityRule: FraudRule = {
+  rule_id:         'rule-002',
+  rule_name:       'High Velocity',
+  rule_type:       'velocity',
+  field_name:      'tx_count_1h',
+  operator:        'gt',
+  threshold_value: '5',
+  weight:          40,
+  priority:        2,
+  is_active:       true,
+  created_by:      null,
+  created_at:      new Date(),
+  updated_at:      new Date(),
+};
+
+const lowWeightRule: FraudRule = {
+  rule_id:         'rule-003',
+  rule_name:       'Low Risk Rule',
+  rule_type:       'threshold',
+  field_name:      'amount',
+  operator:        'gt',
+  threshold_value: '100',
+  weight:          10,
+  priority:        3,
+  is_active:       true,
+  created_by:      null,
+  created_at:      new Date(),
+  updated_at:      new Date(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Default: transaction has NOT been evaluated before
+  mockPool.query.mockResolvedValue({ rows: [], rowCount: 0 } as never);
+  mockGetVelocity.mockResolvedValue(mockVelocity);
+});
+
+// ─── isAlreadyEvaluated Tests ─────────────────────────────────────────────────
+
+describe('isAlreadyEvaluated', () => {
+
+  test('returns false when tx_id has no existing evaluation', async () => {
+    mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 } as never);
+    const result = await isAlreadyEvaluated('tx-new');
+    expect(result).toBe(false);
+  });
+
+  test('returns true when tx_id already exists in risk_logs', async () => {
+    mockPool.query.mockResolvedValueOnce({ rows: [{ 1: 1 }], rowCount: 1 } as never);
+    const result = await isAlreadyEvaluated('tx-existing');
+    expect(result).toBe(true);
+  });
+
+  test('queries risk_logs table with the correct tx_id', async () => {
+    mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 } as never);
+    await isAlreadyEvaluated('tx-check-001');
+    expect(mockPool.query).toHaveBeenCalledWith(
+      expect.stringContaining('risk_logs'),
+      ['tx-check-001']
+    );
+  });
+});
+
+// ─── runEvaluation — Full Pipeline Tests ─────────────────────────────────────
+
+describe('runEvaluation — full pipeline', () => {
+
+  test('returns explainable output with correct tx_id', async () => {
+    const result = await runEvaluation(mockTransaction, [highAmountRule]);
+    expect(result.tx_id).toBe('tx-001');
+  });
+
+  test('returns a valid decision (ALLOW, REVIEW, or BLOCK)', async () => {
+    const result = await runEvaluation(mockTransaction, [highAmountRule]);
+    expect(['ALLOW', 'REVIEW', 'BLOCK']).toContain(result.decision);
+  });
+
+  test('returns risk_score as a number', async () => {
+    const result = await runEvaluation(mockTransaction, [highAmountRule]);
+    expect(typeof result.risk_score).toBe('number');
+  });
+
+  test('includes triggered_rules in output', async () => {
+    const result = await runEvaluation(mockTransaction, [highAmountRule]);
+    expect(Array.isArray(result.triggered_rules)).toBe(true);
+  });
+
+  test('includes score_breakdown in output', async () => {
+    const result = await runEvaluation(mockTransaction, [highAmountRule]);
+    expect(Array.isArray(result.score_breakdown)).toBe(true);
+  });
+
+  test('includes evaluation_time as ISO string', async () => {
+    const result = await runEvaluation(mockTransaction, [highAmountRule]);
+    expect(typeof result.evaluation_time).toBe('string');
+    expect(() => new Date(result.evaluation_time)).not.toThrow();
+  });
+});
+
+// ─── runEvaluation — Decision Correctness Tests ───────────────────────────────
+
+describe('runEvaluation — decision correctness', () => {
+
+  test('ALLOW decision when no rules trigger', async () => {
+    const noMatchRule: FraudRule = { ...highAmountRule, threshold_value: '999999' };
+    const result = await runEvaluation(mockTransaction, [noMatchRule]);
+    expect(result.decision).toBe('ALLOW');
+    expect(result.risk_score).toBe(0);
+    expect(result.triggered_rules).toHaveLength(0);
+  });
+
+  test('BLOCK decision when high weight rules trigger', async () => {
+    const result = await runEvaluation(mockTransaction, [highAmountRule, velocityRule]);
+    expect(result.decision).toBe('BLOCK');    // weight 50 + 40 = 90 → BLOCK
+    expect(result.risk_score).toBe(90);
+  });
+
+  test('REVIEW decision when medium weight rule triggers', async () => {
+    const mediumRule: FraudRule = { ...highAmountRule, weight: 40 };
+    const result = await runEvaluation(mockTransaction, [mediumRule]);
+    expect(result.decision).toBe('REVIEW');   // weight 40 → REVIEW
+    expect(result.risk_score).toBe(40);
+  });
+
+  test('triggered rules list contains only the rules that fired', async () => {
+    const noMatchRule: FraudRule = { ...highAmountRule, rule_id: 'rule-999', threshold_value: '999999' };
+    const result = await runEvaluation(mockTransaction, [highAmountRule, noMatchRule]);
+    expect(result.triggered_rules).toHaveLength(1);
+    expect(result.triggered_rules[0].rule_id).toBe('rule-001');
+  });
+
+  test('score_breakdown matches triggered rules', async () => {
+    const result = await runEvaluation(mockTransaction, [highAmountRule, velocityRule]);
+    expect(result.score_breakdown).toHaveLength(result.triggered_rules.length);
+  });
+
+  test('is_alert_generated is true when score >= 70', async () => {
+    const result = await runEvaluation(mockTransaction, [highAmountRule, velocityRule]);
+    expect(result.is_alert_generated).toBe(true);  // score 90 >= 70
+  });
+
+  test('is_alert_generated is false when score < 70', async () => {
+    const result = await runEvaluation(mockTransaction, [lowWeightRule]);
+    expect(result.is_alert_generated).toBe(false); // score 10 < 70
+  });
+
+  test('empty rules list → ALLOW with score 0', async () => {
+    const result = await runEvaluation(mockTransaction, []);
+    expect(result.decision).toBe('ALLOW');
+    expect(result.risk_score).toBe(0);
+    expect(result.triggered_rules).toHaveLength(0);
+  });
+});
+
+// ─── Idempotency Tests ────────────────────────────────────────────────────────
+
+describe('runEvaluation — idempotency', () => {
+
+  test('throws error if transaction has already been evaluated', async () => {
+    // First call: not evaluated
+    mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 } as never);
+    await runEvaluation(mockTransaction, [highAmountRule]);
+
+    // Second call: already evaluated
+    mockPool.query.mockResolvedValueOnce({ rows: [{ 1: 1 }], rowCount: 1 } as never);
+    await expect(runEvaluation(mockTransaction, [highAmountRule]))
+      .rejects.toThrow(`Transaction ${mockTransaction.tx_id} has already been evaluated`);
+  });
+
+  test('error message contains the duplicate tx_id', async () => {
+    mockPool.query.mockResolvedValueOnce({ rows: [{ 1: 1 }], rowCount: 1 } as never);
+    await expect(runEvaluation(mockTransaction, []))
+      .rejects.toThrow('tx-001');
+  });
+
+  test('velocityChecker is NOT called for duplicate transactions', async () => {
+    mockPool.query.mockResolvedValueOnce({ rows: [{ 1: 1 }], rowCount: 1 } as never);
+    await expect(runEvaluation(mockTransaction, [])).rejects.toThrow();
+    expect(mockGetVelocity).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Integration with velocityChecker Tests ───────────────────────────────────
+
+describe('runEvaluation — velocityChecker integration', () => {
+
+  test('calls velocityChecker with correct user_id', async () => {
+    await runEvaluation(mockTransaction, []);
+    expect(mockGetVelocity).toHaveBeenCalledWith('user-001', expect.any(Date));
+  });
+
+  test('calls velocityChecker exactly once per evaluation', async () => {
+    await runEvaluation(mockTransaction, [highAmountRule]);
+    expect(mockGetVelocity).toHaveBeenCalledTimes(1);
+  });
+
+  test('velocity rule triggers correctly using mocked velocity data', async () => {
+    // tx_count_1h = 8, rule threshold = 5 → should trigger
+    const result = await runEvaluation(mockTransaction, [velocityRule]);
+    expect(result.triggered_rules).toHaveLength(1);
+    expect(result.triggered_rules[0].rule_name).toBe('High Velocity');
+  });
+
+  test('velocity rule does not trigger when count is within limit', async () => {
+    mockGetVelocity.mockResolvedValueOnce({ ...mockVelocity, tx_count_1h: 2 });
+    const result = await runEvaluation(mockTransaction, [velocityRule]);
+    expect(result.triggered_rules).toHaveLength(0);
+  });
+});

--- a/backend/tests/unit/velocityChecker.test.ts
+++ b/backend/tests/unit/velocityChecker.test.ts
@@ -1,1 +1,148 @@
-// Velocity checker tests
+// Mock the DB pool BEFORE importing velocityChecker
+jest.mock('../../src/db/client', () => ({
+  query: jest.fn(),
+}));
+
+import pool from '../../src/db/client';
+import { getVelocityData } from '../../src/engine/velocityChecker';
+
+const mockPool = pool as jest.Mocked<typeof pool>;
+
+// Reference time used across all tests
+const referenceTime = new Date('2026-04-12T10:00:00Z');
+const userId        = 'user-001';
+
+// Helper to set up mock DB responses for both 1h and 24h queries
+function mockDbResponses(
+  count1h: number, total1h: number,
+  count24h: number, total24h: number
+) {
+  mockPool.query
+    .mockResolvedValueOnce({ rows: [{ count: String(count1h), total: String(total1h) }] } as never)
+    .mockResolvedValueOnce({ rows: [{ count: String(count24h), total: String(total24h) }] } as never);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ─── Return Shape Tests ───────────────────────────────────────────────────────
+
+describe('getVelocityData — return shape', () => {
+
+  test('returns all four velocity fields', async () => {
+    mockDbResponses(3, 5000, 10, 25000);
+    const result = await getVelocityData(userId, referenceTime);
+
+    expect(result).toHaveProperty('tx_count_1h');
+    expect(result).toHaveProperty('tx_amount_1h');
+    expect(result).toHaveProperty('tx_count_24h');
+    expect(result).toHaveProperty('tx_amount_24h');
+  });
+
+  test('returns numeric values for all fields', async () => {
+    mockDbResponses(3, 5000, 10, 25000);
+    const result = await getVelocityData(userId, referenceTime);
+
+    expect(typeof result.tx_count_1h).toBe('number');
+    expect(typeof result.tx_amount_1h).toBe('number');
+    expect(typeof result.tx_count_24h).toBe('number');
+    expect(typeof result.tx_amount_24h).toBe('number');
+  });
+});
+
+// ─── Value Correctness Tests ──────────────────────────────────────────────────
+
+describe('getVelocityData — value correctness', () => {
+
+  test('returns correct 1h count and amount', async () => {
+    mockDbResponses(5, 12000, 20, 60000);
+    const result = await getVelocityData(userId, referenceTime);
+
+    expect(result.tx_count_1h).toBe(5);
+    expect(result.tx_amount_1h).toBe(12000);
+  });
+
+  test('returns correct 24h count and amount', async () => {
+    mockDbResponses(5, 12000, 20, 60000);
+    const result = await getVelocityData(userId, referenceTime);
+
+    expect(result.tx_count_24h).toBe(20);
+    expect(result.tx_amount_24h).toBe(60000);
+  });
+
+  test('returns 0 count and 0 amount when user has no recent transactions', async () => {
+    mockDbResponses(0, 0, 0, 0);
+    const result = await getVelocityData(userId, referenceTime);
+
+    expect(result.tx_count_1h).toBe(0);
+    expect(result.tx_amount_1h).toBe(0);
+    expect(result.tx_count_24h).toBe(0);
+    expect(result.tx_amount_24h).toBe(0);
+  });
+
+  test('24h count is always >= 1h count', async () => {
+    mockDbResponses(3, 9000, 12, 45000);
+    const result = await getVelocityData(userId, referenceTime);
+
+    expect(result.tx_count_24h).toBeGreaterThanOrEqual(result.tx_count_1h);
+    expect(result.tx_amount_24h).toBeGreaterThanOrEqual(result.tx_amount_1h);
+  });
+
+  test('handles large transaction counts correctly', async () => {
+    mockDbResponses(100, 500000, 500, 2500000);
+    const result = await getVelocityData(userId, referenceTime);
+
+    expect(result.tx_count_1h).toBe(100);
+    expect(result.tx_amount_1h).toBe(500000);
+    expect(result.tx_count_24h).toBe(500);
+    expect(result.tx_amount_24h).toBe(2500000);
+  });
+});
+
+// ─── DB Query Tests ───────────────────────────────────────────────────────────
+
+describe('getVelocityData — DB queries', () => {
+
+  test('makes exactly 2 DB queries (one for 1h, one for 24h)', async () => {
+    mockDbResponses(3, 5000, 10, 25000);
+    await getVelocityData(userId, referenceTime);
+
+    expect(mockPool.query).toHaveBeenCalledTimes(2);
+  });
+
+  test('passes the correct userId to both queries', async () => {
+    mockDbResponses(3, 5000, 10, 25000);
+    await getVelocityData(userId, referenceTime);
+
+    const firstCall  = (mockPool.query as jest.Mock).mock.calls[0];
+    const secondCall = (mockPool.query as jest.Mock).mock.calls[1];
+
+    expect(firstCall[1][0]).toBe(userId);
+    expect(secondCall[1][0]).toBe(userId);
+  });
+
+  test('1h query uses a time window 1 hour before reference time', async () => {
+    mockDbResponses(3, 5000, 10, 25000);
+    await getVelocityData(userId, referenceTime);
+
+    const firstCall = (mockPool.query as jest.Mock).mock.calls[0];
+    const windowStart: Date = firstCall[1][1];
+    const windowEnd: Date   = firstCall[1][2];
+
+    const diffMs = windowEnd.getTime() - windowStart.getTime();
+    expect(diffMs).toBe(60 * 60 * 1000); // exactly 1 hour
+  });
+
+  test('24h query uses a time window 24 hours before reference time', async () => {
+    mockDbResponses(3, 5000, 10, 25000);
+    await getVelocityData(userId, referenceTime);
+
+    const secondCall = (mockPool.query as jest.Mock).mock.calls[1];
+    const windowStart: Date = secondCall[1][1];
+    const windowEnd: Date   = secondCall[1][2];
+
+    const diffMs = windowEnd.getTime() - windowStart.getTime();
+    expect(diffMs).toBe(24 * 60 * 60 * 1000); // exactly 24 hours
+  });
+});


### PR DESCRIPTION
Closes #14

## Changes

### decisionEngine.ts
- Connects all engine modules into one ordered pipeline
- Step 1: idempotency check (queries risk_logs for existing evaluation)
- Step 2: velocity data fetch (calls velocityChecker)
- Step 3: rule evaluation in priority order (calls ruleEvaluator for each rule)
- Step 4: score aggregation and decision (calls scoreAggregator)
- Step 5: explainable output (calls explainabilityGenerator)
- Throws error if same tx_id is evaluated twice

### decisionEngine.test.ts — 23 tests
- Full pipeline correctness (ALLOW / REVIEW / BLOCK decisions)
- Triggered rules accuracy
- is_alert_generated flag
- Idempotency: duplicate tx throws error, velocityChecker not called

### velocityChecker.test.ts — 12 tests
- Return shape and numeric types
- Correct counts and amounts from mocked DB
- Exactly 2 DB queries per call
- Time windows: exactly 1h and 24h
- Zero transaction handling

## Test Summary
- All 4 unit test files: 110 tests, 110 passing