### PR TITLE
Test: scenario-based integration tests for fraud engine

### DIFF
--- a/backend/tests/scenarios/large_amount.scenario.ts
+++ b/backend/tests/scenarios/large_amount.scenario.ts
@@ -1,1 +1,145 @@
-// Large amount scenario
+// Scenario: Large Amount Transaction
+// A user sends a transaction with a very high amount.
+// Expected: engine triggers high-amount rules → BLOCK decision
+
+jest.mock('../../src/db/client', () => ({ query: jest.fn() }));
+jest.mock('../../src/engine/velocityChecker');
+
+import { getVelocityData } from '../../src/engine/velocityChecker';
+import { runEvaluation, isAlreadyEvaluated } from '../../src/engine/decisionEngine';
+import { FraudRule } from '../../src/types/rule.types';
+import { Transaction } from '../../src/types/transaction.types';
+import { VelocityData } from '../../src/engine/ruleEvaluator';
+import pool from '../../src/db/client';
+
+const mockGetVelocity = getVelocityData as jest.MockedFunction<typeof getVelocityData>;
+const mockPool        = pool as jest.Mocked<typeof pool>;
+
+// ─── Scenario Setup ───────────────────────────────────────────────────────────
+
+// Transaction: user sends ₹85,000 — well above any safe threshold
+const largeAmountTransaction: Transaction = {
+  tx_id:            'scenario-large-001',
+  user_id:          'user-001',
+  amount:           85000,
+  location:         'US',
+  device_id:        'device-001',
+  transaction_time: new Date('2026-04-12T14:00:00Z'), // 2 PM — normal business hours
+  is_simulation:    false,
+  created_at:       new Date(),
+};
+
+// Rules active in this scenario
+const scenarioRules: FraudRule[] = [
+  {
+    rule_id:         'rule-001',
+    rule_name:       'High Amount Block',
+    rule_type:       'threshold',
+    field_name:      'amount',
+    operator:        'gt',
+    threshold_value: '50000',
+    weight:          70,
+    priority:        1,
+    is_active:       true,
+    created_by:      null,
+    created_at:      new Date(),
+    updated_at:      new Date(),
+  },
+  {
+    rule_id:         'rule-002',
+    rule_name:       'Medium Amount Review',
+    rule_type:       'threshold',
+    field_name:      'amount',
+    operator:        'gt',
+    threshold_value: '10000',
+    weight:          30,
+    priority:        2,
+    is_active:       true,
+    created_by:      null,
+    created_at:      new Date(),
+    updated_at:      new Date(),
+  },
+  {
+    rule_id:         'rule-003',
+    rule_name:       'Safe Amount',
+    rule_type:       'threshold',
+    field_name:      'amount',
+    operator:        'lte',
+    threshold_value: '5000',
+    weight:          10,
+    priority:        3,
+    is_active:       true,
+    created_by:      null,
+    created_at:      new Date(),
+    updated_at:      new Date(),
+  },
+];
+
+// Normal velocity — not suspicious
+const normalVelocity: VelocityData = {
+  tx_count_1h:   1,
+  tx_count_24h:  3,
+  tx_amount_1h:  85000,
+  tx_amount_24h: 90000,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPool.query.mockResolvedValue({ rows: [], rowCount: 0 } as never);
+  mockGetVelocity.mockResolvedValue(normalVelocity);
+});
+
+// ─── Scenario Tests ───────────────────────────────────────────────────────────
+
+describe('Scenario: Large Amount Transaction', () => {
+
+  test('decision is BLOCK for very large amount (₹85,000)', async () => {
+    const result = await runEvaluation(largeAmountTransaction, scenarioRules);
+    expect(result.decision).toBe('BLOCK');
+  });
+
+  test('risk score is >= 70 (BLOCK threshold)', async () => {
+    const result = await runEvaluation(largeAmountTransaction, scenarioRules);
+    expect(result.risk_score).toBeGreaterThanOrEqual(70);
+  });
+
+  test('both amount rules trigger (rule-001 and rule-002)', async () => {
+    const result = await runEvaluation(largeAmountTransaction, scenarioRules);
+    const triggeredIds = result.triggered_rules.map(r => r.rule_id);
+    expect(triggeredIds).toContain('rule-001');
+    expect(triggeredIds).toContain('rule-002');
+  });
+
+  test('safe amount rule (lte 5000) does NOT trigger', async () => {
+    const result = await runEvaluation(largeAmountTransaction, scenarioRules);
+    const triggeredIds = result.triggered_rules.map(r => r.rule_id);
+    expect(triggeredIds).not.toContain('rule-003');
+  });
+
+  test('is_alert_generated is true', async () => {
+    const result = await runEvaluation(largeAmountTransaction, scenarioRules);
+    expect(result.is_alert_generated).toBe(true);
+  });
+
+  test('output includes score_breakdown with triggered rule names', async () => {
+    const result = await runEvaluation(largeAmountTransaction, scenarioRules);
+    const ruleNames = result.score_breakdown.map(r => r.rule_name);
+    expect(ruleNames).toContain('High Amount Block');
+    expect(ruleNames).toContain('Medium Amount Review');
+  });
+
+  test('output includes human-readable reason for each triggered rule', async () => {
+    const result = await runEvaluation(largeAmountTransaction, scenarioRules);
+    result.triggered_rules.forEach(rule => {
+      expect(rule.reason).toBeTruthy();
+      expect(typeof rule.reason).toBe('string');
+    });
+  });
+
+  test('a safe transaction (₹3,000) results in ALLOW', async () => {
+    const safeTx = { ...largeAmountTransaction, tx_id: 'scenario-safe-001', amount: 3000 };
+    const result = await runEvaluation(safeTx, scenarioRules);
+    expect(result.decision).toBe('ALLOW');
+    expect(result.risk_score).toBe(10); // rule-003 (lte 5000, weight 10) triggers for ₹3,000
+  });
+});

--- a/backend/tests/scenarios/night_txn.scenario.ts
+++ b/backend/tests/scenarios/night_txn.scenario.ts
@@ -1,1 +1,141 @@
-// Night transaction scenario
+// Scenario: Night Time Transaction
+// A user sends a transaction at 2 AM — outside normal business hours.
+// Expected: temporal rules trigger → REVIEW or BLOCK decision
+
+jest.mock('../../src/db/client', () => ({ query: jest.fn() }));
+jest.mock('../../src/engine/velocityChecker');
+
+import { getVelocityData } from '../../src/engine/velocityChecker';
+import { runEvaluation } from '../../src/engine/decisionEngine';
+import { FraudRule } from '../../src/types/rule.types';
+import { Transaction } from '../../src/types/transaction.types';
+import { VelocityData } from '../../src/engine/ruleEvaluator';
+import pool from '../../src/db/client';
+
+const mockGetVelocity = getVelocityData as jest.MockedFunction<typeof getVelocityData>;
+const mockPool        = pool as jest.Mocked<typeof pool>;
+
+// ─── Scenario Setup ───────────────────────────────────────────────────────────
+
+// Transaction at 2:30 AM UTC — suspicious night hour
+const nightTransaction: Transaction = {
+  tx_id:            'scenario-night-001',
+  user_id:          'user-002',
+  amount:           8000,
+  location:         'US',
+  device_id:        'device-002',
+  transaction_time: new Date('2026-04-12T02:30:00Z'), // 2:30 AM UTC
+  is_simulation:    false,
+  created_at:       new Date(),
+};
+
+// Same transaction but during daytime
+const dayTransaction: Transaction = {
+  tx_id:            'scenario-day-001',
+  user_id:          'user-002',
+  amount:           8000,
+  location:         'US',
+  device_id:        'device-002',
+  transaction_time: new Date('2026-04-12T10:00:00Z'), // 10:00 AM UTC
+  is_simulation:    false,
+  created_at:       new Date(),
+};
+
+const scenarioRules: FraudRule[] = [
+  {
+    rule_id:         'rule-001',
+    rule_name:       'Night Hour Transaction',
+    rule_type:       'temporal',
+    field_name:      'hour_of_day',
+    operator:        'in',
+    threshold_value: '0,1,2,3,4,5,22,23',
+    weight:          40,
+    priority:        1,
+    is_active:       true,
+    created_by:      null,
+    created_at:      new Date(),
+    updated_at:      new Date(),
+  },
+  {
+    rule_id:         'rule-002',
+    rule_name:       'Medium Amount',
+    rule_type:       'threshold',
+    field_name:      'amount',
+    operator:        'gt',
+    threshold_value: '5000',
+    weight:          30,
+    priority:        2,
+    is_active:       true,
+    created_by:      null,
+    created_at:      new Date(),
+    updated_at:      new Date(),
+  },
+];
+
+const normalVelocity: VelocityData = {
+  tx_count_1h:   1,
+  tx_count_24h:  2,
+  tx_amount_1h:  8000,
+  tx_amount_24h: 10000,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPool.query.mockResolvedValue({ rows: [], rowCount: 0 } as never);
+  mockGetVelocity.mockResolvedValue(normalVelocity);
+});
+
+// ─── Scenario Tests ───────────────────────────────────────────────────────────
+
+describe('Scenario: Night Time Transaction', () => {
+
+  test('decision is BLOCK for night transaction with medium amount', async () => {
+    const result = await runEvaluation(nightTransaction, scenarioRules);
+    expect(['REVIEW', 'BLOCK']).toContain(result.decision);
+    expect(result.risk_score).toBeGreaterThanOrEqual(30); // at least REVIEW
+  });
+
+  test('night hour rule triggers at 2:30 AM', async () => {
+    const result = await runEvaluation(nightTransaction, scenarioRules);
+    const triggeredIds = result.triggered_rules.map(r => r.rule_id);
+    expect(triggeredIds).toContain('rule-001');
+  });
+
+  test('amount rule also triggers (8000 > 5000)', async () => {
+    const result = await runEvaluation(nightTransaction, scenarioRules);
+    const triggeredIds = result.triggered_rules.map(r => r.rule_id);
+    expect(triggeredIds).toContain('rule-002');
+  });
+
+  test('combined score is 70 → BLOCK decision', async () => {
+    const result = await runEvaluation(nightTransaction, scenarioRules);
+    expect(result.risk_score).toBe(70);   // weight 40 + 30 = 70
+    expect(result.decision).toBe('BLOCK');
+  });
+
+  test('daytime transaction does NOT trigger night hour rule', async () => {
+    const result = await runEvaluation(dayTransaction, scenarioRules);
+    const triggeredIds = result.triggered_rules.map(r => r.rule_id);
+    expect(triggeredIds).not.toContain('rule-001');
+  });
+
+  test('daytime transaction with same amount → REVIEW (only amount rule triggers)', async () => {
+    const result = await runEvaluation(dayTransaction, scenarioRules);
+    expect(result.decision).toBe('REVIEW'); // only weight 30 → REVIEW
+    expect(result.risk_score).toBe(30);
+  });
+
+  test('output includes explanation of why night rule triggered', async () => {
+    const result = await runEvaluation(nightTransaction, scenarioRules);
+    const nightRule = result.triggered_rules.find(r => r.rule_id === 'rule-001');
+    expect(nightRule).toBeDefined();
+    expect(nightRule?.reason).toContain('hour_of_day');
+  });
+
+  test('score_breakdown lists all triggered rules with weights', async () => {
+    const result = await runEvaluation(nightTransaction, scenarioRules);
+    expect(result.score_breakdown).toHaveLength(2);
+    const totalWeight = result.score_breakdown.reduce((sum, r) => sum + r.weight, 0);
+    expect(totalWeight).toBe(result.risk_score);
+  });
+});

--- a/backend/tests/scenarios/rapid_velocity.scenario.ts
+++ b/backend/tests/scenarios/rapid_velocity.scenario.ts
@@ -1,1 +1,162 @@
-// Rapid velocity test scenario
+// Scenario: Rapid Velocity Transactions
+// A user makes 10 transactions within the last 1 hour — highly suspicious pattern.
+// Expected: velocity rules trigger → BLOCK decision
+
+jest.mock('../../src/db/client', () => ({ query: jest.fn() }));
+jest.mock('../../src/engine/velocityChecker');
+
+import { getVelocityData } from '../../src/engine/velocityChecker';
+import { runEvaluation } from '../../src/engine/decisionEngine';
+import { FraudRule } from '../../src/types/rule.types';
+import { Transaction } from '../../src/types/transaction.types';
+import { VelocityData } from '../../src/engine/ruleEvaluator';
+import pool from '../../src/db/client';
+
+const mockGetVelocity = getVelocityData as jest.MockedFunction<typeof getVelocityData>;
+const mockPool        = pool as jest.Mocked<typeof pool>;
+
+// ─── Scenario Setup ───────────────────────────────────────────────────────────
+
+// Transaction from a user who has been very active in the last hour
+const rapidTransaction: Transaction = {
+  tx_id:            'scenario-rapid-001',
+  user_id:          'user-003',
+  amount:           2000,
+  location:         'IN',
+  device_id:        'device-003',
+  transaction_time: new Date('2026-04-12T14:00:00Z'),
+  is_simulation:    false,
+  created_at:       new Date(),
+};
+
+const scenarioRules: FraudRule[] = [
+  {
+    rule_id:         'rule-001',
+    rule_name:       'High Transaction Frequency 1h',
+    rule_type:       'velocity',
+    field_name:      'tx_count_1h',
+    operator:        'gt',
+    threshold_value: '5',
+    weight:          50,
+    priority:        1,
+    is_active:       true,
+    created_by:      null,
+    created_at:      new Date(),
+    updated_at:      new Date(),
+  },
+  {
+    rule_id:         'rule-002',
+    rule_name:       'High Spend 1h',
+    rule_type:       'velocity',
+    field_name:      'tx_amount_1h',
+    operator:        'gt',
+    threshold_value: '10000',
+    weight:          30,
+    priority:        2,
+    is_active:       true,
+    created_by:      null,
+    created_at:      new Date(),
+    updated_at:      new Date(),
+  },
+  {
+    rule_id:         'rule-003',
+    rule_name:       'High Transaction Frequency 24h',
+    rule_type:       'velocity',
+    field_name:      'tx_count_24h',
+    operator:        'gt',
+    threshold_value: '15',
+    weight:          20,
+    priority:        3,
+    is_active:       true,
+    created_by:      null,
+    created_at:      new Date(),
+    updated_at:      new Date(),
+  },
+];
+
+// Suspicious velocity: 10 transactions in 1 hour
+const highVelocity: VelocityData = {
+  tx_count_1h:   10,
+  tx_count_24h:  20,
+  tx_amount_1h:  20000,
+  tx_amount_24h: 40000,
+};
+
+// Normal velocity: 2 transactions in 1 hour
+const normalVelocity: VelocityData = {
+  tx_count_1h:   2,
+  tx_count_24h:  5,
+  tx_amount_1h:  4000,
+  tx_amount_24h: 10000,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPool.query.mockResolvedValue({ rows: [], rowCount: 0 } as never);
+  mockGetVelocity.mockResolvedValue(highVelocity);
+});
+
+// ─── Scenario Tests ───────────────────────────────────────────────────────────
+
+describe('Scenario: Rapid Velocity Transactions', () => {
+
+  test('decision is BLOCK when user has 10 transactions in last 1 hour', async () => {
+    const result = await runEvaluation(rapidTransaction, scenarioRules);
+    expect(result.decision).toBe('BLOCK');
+  });
+
+  test('risk score is >= 70 (BLOCK threshold)', async () => {
+    const result = await runEvaluation(rapidTransaction, scenarioRules);
+    expect(result.risk_score).toBeGreaterThanOrEqual(70);
+  });
+
+  test('all 3 velocity rules trigger with high velocity data', async () => {
+    const result = await runEvaluation(rapidTransaction, scenarioRules);
+    expect(result.triggered_rules).toHaveLength(3);
+  });
+
+  test('frequency 1h rule triggers (10 > 5)', async () => {
+    const result = await runEvaluation(rapidTransaction, scenarioRules);
+    const triggeredIds = result.triggered_rules.map(r => r.rule_id);
+    expect(triggeredIds).toContain('rule-001');
+  });
+
+  test('spend 1h rule triggers (20000 > 10000)', async () => {
+    const result = await runEvaluation(rapidTransaction, scenarioRules);
+    const triggeredIds = result.triggered_rules.map(r => r.rule_id);
+    expect(triggeredIds).toContain('rule-002');
+  });
+
+  test('frequency 24h rule triggers (20 > 15)', async () => {
+    const result = await runEvaluation(rapidTransaction, scenarioRules);
+    const triggeredIds = result.triggered_rules.map(r => r.rule_id);
+    expect(triggeredIds).toContain('rule-003');
+  });
+
+  test('is_alert_generated is true', async () => {
+    const result = await runEvaluation(rapidTransaction, scenarioRules);
+    expect(result.is_alert_generated).toBe(true);
+  });
+
+  test('score_breakdown weights sum equals risk_score', async () => {
+    const result = await runEvaluation(rapidTransaction, scenarioRules);
+    const total = result.score_breakdown.reduce((sum, r) => sum + r.weight, 0);
+    expect(total).toBe(result.risk_score);
+  });
+
+  test('normal velocity → ALLOW (no velocity rules trigger)', async () => {
+    mockGetVelocity.mockResolvedValueOnce(normalVelocity);
+    const safeTx = { ...rapidTransaction, tx_id: 'scenario-safe-001' };
+    const result = await runEvaluation(safeTx, scenarioRules);
+    expect(result.decision).toBe('ALLOW');
+    expect(result.triggered_rules).toHaveLength(0);
+  });
+
+  test('borderline velocity (exactly 5 tx_count_1h) does NOT trigger frequency rule', async () => {
+    mockGetVelocity.mockResolvedValueOnce({ ...normalVelocity, tx_count_1h: 5 });
+    const borderTx = { ...rapidTransaction, tx_id: 'scenario-border-001' };
+    const result = await runEvaluation(borderTx, scenarioRules);
+    const triggeredIds = result.triggered_rules.map(r => r.rule_id);
+    expect(triggeredIds).not.toContain('rule-001'); // gt 5, not gte — exactly 5 should not trigger
+  });
+});


### PR DESCRIPTION
Closes #15 

## What this PR does

Adds 3 scenario test files that simulate real-world fraud patterns end-to-end through the full engine pipeline (runEvaluation).

## Scenarios covered

- **large_amount.scenario.ts** (8 tests) — ₹85,000 transaction triggers two threshold rules → BLOCK. ₹3,000 safe transaction → ALLOW.

- **night_txn.scenario.ts** (8 tests) — 2:30 AM UTC + ₹8,000 triggers temporal + amount rules (weight 40+30=70) → BLOCK. Same transaction at 10 AM → REVIEW.

- **rapid_velocity.scenario.ts** (10 tests) — 10 transactions in 1 hour triggers all 3 velocity rules → BLOCK. Normal velocity → ALLOW. Borderline (exactly 5 tx) does NOT trigger a gt 5 rule.

## Test results

136 tests pass across 7 test suites (4 unit + 3 scenario).