### PR TITLE
Complete all database migration files

### DIFF
--- a/backend/src/db/migrations/001_create_users.sql
+++ b/backend/src/db/migrations/001_create_users.sql
@@ -1,1 +1,8 @@
--- Create users table
+CREATE TABLE IF NOT EXISTS users (
+  user_id     UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+  email       VARCHAR(255)  NOT NULL UNIQUE,
+  name        VARCHAR(100)  NOT NULL,
+  is_active   BOOLEAN       NOT NULL DEFAULT true,
+  created_at  TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);

--- a/backend/src/db/migrations/002_create_fraud_rules.sql
+++ b/backend/src/db/migrations/002_create_fraud_rules.sql
@@ -1,13 +1,15 @@
 CREATE TABLE IF NOT EXISTS fraud_rules (
-  id          UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
-  name        VARCHAR(100)  NOT NULL,
-  description TEXT,
-  type        VARCHAR(20)   NOT NULL CHECK (type IN ('threshold', 'velocity', 'temporal', 'composite')),
-  field       VARCHAR(50)   NOT NULL,
-  operator    VARCHAR(10)   NOT NULL CHECK (operator IN ('gt', 'lt', 'eq', 'gte', 'lte', 'in', 'not_in')),
-  value       NUMERIC       NOT NULL,
-  weight      INTEGER       NOT NULL CHECK (weight BETWEEN 1 AND 100),
-  is_active   BOOLEAN       NOT NULL DEFAULT true,
-  created_at  TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
-  updated_at  TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+  rule_id         UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+  rule_name       VARCHAR(100)  NOT NULL UNIQUE,
+  description     TEXT,
+  rule_type       VARCHAR(20)   NOT NULL CHECK (rule_type IN ('threshold', 'velocity', 'temporal')),
+  field_name      VARCHAR(50)   NOT NULL,
+  operator        VARCHAR(10)   NOT NULL CHECK (operator IN ('gt', 'lt', 'gte', 'lte', 'eq', 'neq', 'in', 'not_in', 'range', 'regex')),
+  threshold_value TEXT          NOT NULL,
+  weight          INTEGER       NOT NULL CHECK (weight BETWEEN 1 AND 100),
+  priority        INTEGER       NOT NULL DEFAULT 10,
+  is_active       BOOLEAN       NOT NULL DEFAULT true,
+  created_by      UUID          REFERENCES users(user_id) ON DELETE SET NULL,
+  created_at      TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ   NOT NULL DEFAULT NOW()
 );

--- a/backend/src/db/migrations/003_create_transactions.sql
+++ b/backend/src/db/migrations/003_create_transactions.sql
@@ -1,1 +1,13 @@
--- Create transactions table
+CREATE TABLE IF NOT EXISTS transactions (
+  tx_id             UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           UUID          NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+  amount            NUMERIC(12,2) NOT NULL CHECK (amount > 0),
+  location          VARCHAR(100)  NOT NULL,
+  device_id         VARCHAR(100)  NOT NULL,
+  transaction_time  TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+  is_simulation     BOOLEAN       NOT NULL DEFAULT false,
+  created_at        TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_transactions_user_time
+  ON transactions (user_id, transaction_time);

--- a/backend/src/db/migrations/004_create_transaction_evaluations.sql
+++ b/backend/src/db/migrations/004_create_transaction_evaluations.sql
@@ -1,1 +1,16 @@
--- Create transaction_evaluations table
+-- risk_logs stores the result of each fraud evaluation (one row per transaction)
+CREATE TABLE IF NOT EXISTS risk_logs (
+  id                  UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+  tx_id               UUID          NOT NULL UNIQUE REFERENCES transactions(tx_id) ON DELETE CASCADE,
+  risk_score          INTEGER       NOT NULL CHECK (risk_score >= 0),
+  decision            VARCHAR(10)   NOT NULL CHECK (decision IN ('ALLOW', 'REVIEW', 'BLOCK')),
+  is_alert_generated  BOOLEAN       NOT NULL DEFAULT false,
+  evaluation_time     TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+  created_at          TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_risk_logs_decision
+  ON risk_logs (decision);
+
+CREATE INDEX IF NOT EXISTS idx_risk_logs_evaluation_time
+  ON risk_logs (evaluation_time DESC);

--- a/backend/src/db/migrations/005_create_rule_evaluation_trace.sql
+++ b/backend/src/db/migrations/005_create_rule_evaluation_trace.sql
@@ -1,1 +1,14 @@
--- Create rule_evaluation_trace table
+-- rule_evaluation_trace stores which rules triggered for each evaluation (one row per triggered rule)
+CREATE TABLE IF NOT EXISTS rule_evaluation_trace (
+  id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  tx_id           UUID        NOT NULL REFERENCES transactions(tx_id) ON DELETE CASCADE,
+  rule_id         UUID        NOT NULL REFERENCES fraud_rules(rule_id) ON DELETE CASCADE,
+  rule_name       VARCHAR(100) NOT NULL,
+  rule_type       VARCHAR(20)  NOT NULL,
+  weight_applied  INTEGER      NOT NULL,
+  reason          TEXT         NOT NULL,
+  created_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_trace_tx_id
+  ON rule_evaluation_trace (tx_id);

--- a/backend/src/db/migrations/006_create_velocity_tracking.sql
+++ b/backend/src/db/migrations/006_create_velocity_tracking.sql
@@ -1,1 +1,16 @@
--- Create velocity_tracking table
+-- velocity_tracking caches pre-computed velocity snapshots per user per time window
+-- Used as an optional read-through cache to avoid repeated aggregation queries
+CREATE TABLE IF NOT EXISTS velocity_tracking (
+  id              UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         UUID          NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+  window_start    TIMESTAMPTZ   NOT NULL,
+  window_end      TIMESTAMPTZ   NOT NULL,
+  tx_count        INTEGER       NOT NULL DEFAULT 0,
+  tx_amount_total NUMERIC(14,2) NOT NULL DEFAULT 0,
+  updated_at      TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT uq_velocity_user_window UNIQUE (user_id, window_start, window_end)
+);
+
+CREATE INDEX IF NOT EXISTS idx_velocity_user_window
+  ON velocity_tracking (user_id, window_end DESC);

--- a/backend/src/db/migrations/007_create_devices.sql
+++ b/backend/src/db/migrations/007_create_devices.sql
@@ -1,1 +1,11 @@
--- Create devices table
+CREATE TABLE IF NOT EXISTS devices (
+  device_id       VARCHAR(100)  PRIMARY KEY,
+  user_id         UUID          REFERENCES users(user_id) ON DELETE SET NULL,
+  device_type     VARCHAR(50),
+  os              VARCHAR(50),
+  first_seen_at   TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+  last_seen_at    TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_devices_user_id
+  ON devices (user_id);

--- a/backend/src/db/migrations/008_create_user_transaction_stats.sql
+++ b/backend/src/db/migrations/008_create_user_transaction_stats.sql
@@ -1,1 +1,11 @@
--- Create user_transaction_stats table
+-- Aggregated lifetime stats per user — updated after each evaluated transaction
+CREATE TABLE IF NOT EXISTS user_transaction_stats (
+  user_id           UUID          PRIMARY KEY REFERENCES users(user_id) ON DELETE CASCADE,
+  total_tx_count    INTEGER       NOT NULL DEFAULT 0,
+  total_tx_amount   NUMERIC(16,2) NOT NULL DEFAULT 0,
+  block_count       INTEGER       NOT NULL DEFAULT 0,
+  review_count      INTEGER       NOT NULL DEFAULT 0,
+  allow_count       INTEGER       NOT NULL DEFAULT 0,
+  last_tx_at        TIMESTAMPTZ,
+  updated_at        TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);

--- a/backend/src/db/migrations/009_create_rule_performance_metrics.sql
+++ b/backend/src/db/migrations/009_create_rule_performance_metrics.sql
@@ -1,1 +1,11 @@
--- Create rule_performance_metrics table
+-- Tracks how often each rule triggers and its decision impact — useful for tuning weights
+CREATE TABLE IF NOT EXISTS rule_performance_metrics (
+  rule_id           UUID          PRIMARY KEY REFERENCES fraud_rules(rule_id) ON DELETE CASCADE,
+  total_evaluations INTEGER       NOT NULL DEFAULT 0,
+  total_triggers    INTEGER       NOT NULL DEFAULT 0,
+  block_triggers    INTEGER       NOT NULL DEFAULT 0,
+  review_triggers   INTEGER       NOT NULL DEFAULT 0,
+  allow_triggers    INTEGER       NOT NULL DEFAULT 0,
+  last_triggered_at TIMESTAMPTZ,
+  updated_at        TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);


### PR DESCRIPTION
All 9 SQL migration files were stubs with just a comment. This fills them all in with proper CREATE TABLE statements that match exactly what the engine code queries and expects.

The fraud_rules table was also corrected - the old migration used wrong column names (name, type, field, value) that didn't match what ruleLoader.ts selects (rule_name, rule_type, field_name, threshold_value, priority, created_by). That mismatch would have crashed the server on boot.

Tables added: users, transactions, risk_logs (the idempotency table the decision engine checks), rule_evaluation_trace (stores triggered rules per evaluation), velocity_tracking, devices, user_transaction_stats, rule_performance_metrics. Indexes added on high-frequency query paths - user+time on transactions for velocity checks, decision and evaluation_time on risk_logs for the results API.