### PR TITLE
 Implement Express app entry point and all middleware

### DIFF
--- a/backend/src/api/middlewares/errorHandler.middleware.ts
+++ b/backend/src/api/middlewares/errorHandler.middleware.ts
@@ -1,1 +1,21 @@
-// Error handler middleware
+import { Request, Response, NextFunction } from 'express';
+import { logger } from '../../utils/logger';
+
+export function errorHandler(
+  err: Error,
+  req: Request,
+  res: Response,
+  _next: NextFunction
+): void {
+  logger.error('Unhandled error', {
+    message: err.message,
+    stack:   err.stack,
+    method:  req.method,
+    path:    req.path,
+  });
+
+  res.status(500).json({
+    success: false,
+    error:   'Internal server error',
+  });
+}

--- a/backend/src/api/middlewares/logger.middleware.ts
+++ b/backend/src/api/middlewares/logger.middleware.ts
@@ -1,1 +1,17 @@
-// Logger middleware
+import { Request, Response, NextFunction } from 'express';
+import { logger } from '../../utils/logger';
+
+export function requestLogger(req: Request, res: Response, next: NextFunction): void {
+  const start = Date.now();
+
+  res.on('finish', () => {
+    logger.info('HTTP request', {
+      method:     req.method,
+      path:       req.path,
+      status:     res.statusCode,
+      duration_ms: Date.now() - start,
+    });
+  });
+
+  next();
+}

--- a/backend/src/api/middlewares/validate.middleware.ts
+++ b/backend/src/api/middlewares/validate.middleware.ts
@@ -1,1 +1,18 @@
-// Validation middleware
+import { Request, Response, NextFunction } from 'express';
+import { ZodSchema, ZodError, ZodIssue } from 'zod';
+
+export function validate(schema: ZodSchema) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const result = schema.safeParse(req.body);
+    if (!result.success) {
+      const errors = (result.error as ZodError).errors.map((e: ZodIssue) => ({
+        field:   e.path.join('.'),
+        message: e.message,
+      }));
+      res.status(400).json({ success: false, errors });
+      return;
+    }
+    req.body = result.data;
+    next();
+  };
+}

--- a/backend/src/api/routes/results.routes.ts
+++ b/backend/src/api/routes/results.routes.ts
@@ -1,1 +1,8 @@
-// Results routes
+import { Router } from 'express';
+
+const router = Router();
+
+// GET /api/results     — wired in Issue 5
+// GET /api/results/:id — wired in Issue 5
+
+export default router;

--- a/backend/src/api/routes/rules.routes.ts
+++ b/backend/src/api/routes/rules.routes.ts
@@ -1,1 +1,10 @@
-// Rules routes
+import { Router } from 'express';
+
+const router = Router();
+
+// GET    /api/rules       — wired in Issue 4
+// POST   /api/rules       — wired in Issue 4
+// PATCH  /api/rules/:id   — wired in Issue 4
+// PUT    /api/rules/:id   — wired in Issue 4
+
+export default router;

--- a/backend/src/api/routes/simulate.routes.ts
+++ b/backend/src/api/routes/simulate.routes.ts
@@ -1,1 +1,7 @@
-// Simulate routes
+import { Router } from 'express';
+
+const router = Router();
+
+// POST /api/simulate — wired in Issue 5
+
+export default router;

--- a/backend/src/api/routes/transaction.routes.ts
+++ b/backend/src/api/routes/transaction.routes.ts
@@ -1,1 +1,8 @@
-// Transaction routes
+import { Router } from 'express';
+
+const router = Router();
+
+// POST /api/transactions/evaluate — wired in Issue 3
+// POST /api/transactions           — wired in Issue 3
+
+export default router;

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,1 +1,32 @@
-// Express app setup
+import express from 'express';
+import cors from 'cors';
+import dotenv from 'dotenv';
+
+import { requestLogger } from './api/middlewares/logger.middleware';
+import { errorHandler } from './api/middlewares/errorHandler.middleware';
+
+import transactionRoutes from './api/routes/transaction.routes';
+import rulesRoutes       from './api/routes/rules.routes';
+import simulateRoutes    from './api/routes/simulate.routes';
+import resultsRoutes     from './api/routes/results.routes';
+
+dotenv.config();
+
+const app = express();
+
+app.use(cors());
+app.use(express.json());
+app.use(requestLogger);
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok', timestamp: new Date().toISOString() });
+});
+
+app.use('/api/transactions', transactionRoutes);
+app.use('/api/rules',        rulesRoutes);
+app.use('/api/simulate',     simulateRoutes);
+app.use('/api/results',      resultsRoutes);
+
+app.use(errorHandler);
+
+export default app;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,0 +1,7 @@
+import app from './app';
+import { logger } from './utils/logger';
+import { PORT } from './utils/constants';
+
+app.listen(PORT, () => {
+  logger.info(`Server running on port ${PORT}`);
+});

--- a/backend/src/utils/alerting.ts
+++ b/backend/src/utils/alerting.ts
@@ -1,1 +1,11 @@
-// Alerting service
+import { logger } from './logger';
+import { ExplainableOutput } from '../engine/explainabilityGenerator';
+
+export function triggerAlert(output: ExplainableOutput): void {
+  logger.warn('FRAUD ALERT', {
+    tx_id:          output.tx_id,
+    decision:       output.decision,
+    risk_score:     output.risk_score,
+    triggered_rules: output.triggered_rules.map(r => r.rule_name),
+  });
+}

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -1,1 +1,13 @@
-// Constants
+export const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
+
+export const SCORE_THRESHOLDS = {
+  REVIEW: 30,
+  BLOCK:  70,
+} as const;
+
+export const ALERT_SCORE_THRESHOLD = 70;
+
+export const VELOCITY_WINDOWS = {
+  ONE_HOUR:        60 * 60 * 1000,
+  TWENTY_FOUR_HOURS: 24 * 60 * 60 * 1000,
+} as const;

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -1,1 +1,23 @@
-// Logger utility
+type LogLevel = 'info' | 'warn' | 'error' | 'debug';
+
+function log(level: LogLevel, message: string, meta?: Record<string, unknown>) {
+  const entry: Record<string, unknown> = {
+    timestamp: new Date().toISOString(),
+    level,
+    message,
+    ...meta,
+  };
+  const output = JSON.stringify(entry);
+  if (level === 'error') {
+    console.error(output);
+  } else {
+    console.log(output);
+  }
+}
+
+export const logger = {
+  info:  (message: string, meta?: Record<string, unknown>) => log('info',  message, meta),
+  warn:  (message: string, meta?: Record<string, unknown>) => log('warn',  message, meta),
+  error: (message: string, meta?: Record<string, unknown>) => log('error', message, meta),
+  debug: (message: string, meta?: Record<string, unknown>) => log('debug', message, meta),
+};


### PR DESCRIPTION
The server had no entry point and no running Express app - app.ts was a single comment and every middleware file was empty.

This wires everything up. index.ts is the server entry point that npm run dev points to. app.ts sets up Express with CORS, JSON body parsing, route mounting under /api/*, and a /health endpoint. The three middlewares are now real: requestLogger logs every request with method, path, status, and duration as structured JSON; validate wraps any Zod schema and returns field-level 400 errors before the controller runs; errorHandler catches anything that falls through and returns a clean 500 without leaking stack traces to the client.

The four route files are wired into the app as proper Express routers - empty for now, controllers get added in the next issues. The logger, constants, and alerting utilities are also implemented. TypeScript compiles with zero errors.