### PR TITLE
 Feature:  Implement transaction evaluation API

### DIFF
--- a/backend/src/api/controllers/transaction.controller.ts
+++ b/backend/src/api/controllers/transaction.controller.ts
@@ -1,1 +1,21 @@
-// Transaction controller
+import { Request, Response, NextFunction } from 'express';
+import { evaluateTransaction } from '../../services/transaction.service';
+import { TransactionInputDTO } from '../../schemas/transaction.schema';
+
+export async function evaluate(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const input = req.body as TransactionInputDTO;
+    const result = await evaluateTransaction(input);
+    res.status(200).json({ success: true, data: result });
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('already been evaluated')) {
+      res.status(409).json({ success: false, error: err.message });
+      return;
+    }
+    next(err);
+  }
+}

--- a/backend/src/api/routes/transaction.routes.ts
+++ b/backend/src/api/routes/transaction.routes.ts
@@ -1,8 +1,11 @@
 import { Router } from 'express';
+import { validate } from '../middlewares/validate.middleware';
+import { transactionInputSchema } from '../../schemas/transaction.schema';
+import { evaluate } from '../controllers/transaction.controller';
 
 const router = Router();
 
-// POST /api/transactions/evaluate — wired in Issue 3
-// POST /api/transactions           — wired in Issue 3
+// POST /api/transactions/evaluate
+router.post('/evaluate', validate(transactionInputSchema), evaluate);
 
 export default router;

--- a/backend/src/schemas/transaction.schema.ts
+++ b/backend/src/schemas/transaction.schema.ts
@@ -1,1 +1,12 @@
-// Transaction schema
+import { z } from 'zod';
+
+export const transactionInputSchema = z.object({
+  user_id:          z.string().uuid({ message: 'user_id must be a valid UUID' }),
+  amount:           z.number().positive({ message: 'amount must be greater than 0' }),
+  location:         z.string().min(1, { message: 'location is required' }),
+  device_id:        z.string().min(1, { message: 'device_id is required' }),
+  transaction_time: z.string().datetime({ message: 'transaction_time must be an ISO 8601 datetime' }).optional(),
+  is_simulation:    z.boolean().optional().default(false),
+});
+
+export type TransactionInputDTO = z.infer<typeof transactionInputSchema>;

--- a/backend/src/services/transaction.service.ts
+++ b/backend/src/services/transaction.service.ts
@@ -1,1 +1,82 @@
-// Transaction service implementation
+import pool from '../db/client';
+import { Transaction } from '../types/transaction.types';
+import { TransactionInputDTO } from '../schemas/transaction.schema';
+import { loadActiveRules } from '../engine/ruleLoader';
+import { runEvaluation } from '../engine/decisionEngine';
+import { ExplainableOutput } from '../engine/explainabilityGenerator';
+import { triggerAlert } from '../utils/alerting';
+import { logger } from '../utils/logger';
+
+// Persist the raw transaction row and return the full Transaction object
+async function insertTransaction(input: TransactionInputDTO): Promise<Transaction> {
+  const result = await pool.query<Transaction>(
+    `INSERT INTO transactions (user_id, amount, location, device_id, transaction_time, is_simulation)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING *`,
+    [
+      input.user_id,
+      input.amount,
+      input.location,
+      input.device_id,
+      input.transaction_time ? new Date(input.transaction_time) : new Date(),
+      input.is_simulation ?? false,
+    ]
+  );
+  return result.rows[0];
+}
+
+// Persist the evaluation result into risk_logs and rule_evaluation_trace
+async function persistEvaluation(output: ExplainableOutput): Promise<void> {
+  await pool.query(
+    `INSERT INTO risk_logs (tx_id, risk_score, decision, is_alert_generated, evaluation_time)
+     VALUES ($1, $2, $3, $4, $5)`,
+    [
+      output.tx_id,
+      output.risk_score,
+      output.decision,
+      output.is_alert_generated,
+      new Date(output.evaluation_time),
+    ]
+  );
+
+  if (output.triggered_rules.length > 0) {
+    const values = output.triggered_rules.map((_, i) => {
+      const base = i * 5;
+      return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5})`;
+    }).join(', ');
+
+    const params = output.triggered_rules.flatMap(r => [
+      output.tx_id,
+      r.rule_id,
+      r.rule_name,
+      r.rule_type,
+      r.reason,
+    ]);
+
+    await pool.query(
+      `INSERT INTO rule_evaluation_trace (tx_id, rule_id, rule_name, rule_type, reason)
+       VALUES ${values}`,
+      params
+    );
+  }
+}
+
+// Main service function — called by the controller
+export async function evaluateTransaction(
+  input: TransactionInputDTO
+): Promise<ExplainableOutput> {
+  const tx    = await insertTransaction(input);
+  const rules = await loadActiveRules();
+
+  logger.info('Evaluating transaction', { tx_id: tx.tx_id, rules_loaded: rules.length });
+
+  const output = await runEvaluation(tx, rules);
+
+  await persistEvaluation(output);
+
+  if (output.is_alert_generated) {
+    triggerAlert(output);
+  }
+
+  return output;
+}


### PR DESCRIPTION
Completes #25 
### Feature Description: 
This wires up the core feature of the entire project  - POST /api/transactions/evaluate. Before this, the engine existed but had no API surface.

The flow is: request hits the route → Zod validates the body via the validate middleware → controller calls the service → service inserts the transaction into the DB, loads active rules, runs the full engine pipeline (runEvaluation), persists the fraud decision to risk_logs and every triggered rule to rule_evaluation_trace, fires an alert log if is_alert_generated is true, and returns the full explainable JSON output back to the client.

Idempotency is handled - if the same tx_id comes through twice, the engine throws and the controller returns a 409. The Zod schema enforces user_id as UUID, amount as a positive number, and transaction_time as ISO 8601. All four layers (schema, service, controller, route) are type-safe with zero TypeScript errors.

New PR after resolving conflicts of PR #33 