### PR TITLE
Implement rules management API with full CRUD and fix schema mismatch

### DIFF
--- a/backend/src/api/controllers/rules.controller.ts
+++ b/backend/src/api/controllers/rules.controller.ts
@@ -1,1 +1,77 @@
-// Rules controller
+import { Request, Response, NextFunction } from 'express';
+import * as rulesService from '../../services/rules.service';
+import { CreateRuleDTO, UpdateRuleDTO, ToggleRuleDTO } from '../../schemas/rule.schema';
+
+export async function getAll(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const rules = await rulesService.getAllRules();
+    res.status(200).json({ success: true, data: rules });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getOne(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const rule = await rulesService.getRuleById(req.params.id);
+    if (!rule) {
+      res.status(404).json({ success: false, error: 'Rule not found' });
+      return;
+    }
+    res.status(200).json({ success: true, data: rule });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function create(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const rule = await rulesService.createRule(req.body as CreateRuleDTO);
+    res.status(201).json({ success: true, data: rule });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message.includes('unique')) {
+      res.status(409).json({ success: false, error: 'A rule with that name already exists' });
+      return;
+    }
+    next(err);
+  }
+}
+
+export async function update(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const rule = await rulesService.updateRule(req.params.id, req.body as UpdateRuleDTO);
+    if (!rule) {
+      res.status(404).json({ success: false, error: 'Rule not found' });
+      return;
+    }
+    res.status(200).json({ success: true, data: rule });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function toggle(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const rule = await rulesService.toggleRule(req.params.id, req.body as ToggleRuleDTO);
+    if (!rule) {
+      res.status(404).json({ success: false, error: 'Rule not found' });
+      return;
+    }
+    res.status(200).json({ success: true, data: rule });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function remove(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const deleted = await rulesService.deleteRule(req.params.id);
+    if (!deleted) {
+      res.status(404).json({ success: false, error: 'Rule not found' });
+      return;
+    }
+    res.status(200).json({ success: true, message: 'Rule deleted' });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/api/routes/rules.routes.ts
+++ b/backend/src/api/routes/rules.routes.ts
@@ -1,10 +1,15 @@
 import { Router } from 'express';
+import { validate } from '../middlewares/validate.middleware';
+import { createRuleSchema, updateRuleSchema, toggleRuleSchema } from '../../schemas/rule.schema';
+import { getAll, getOne, create, update, toggle, remove } from '../controllers/rules.controller';
 
 const router = Router();
 
-// GET    /api/rules       — wired in Issue 4
-// POST   /api/rules       — wired in Issue 4
-// PATCH  /api/rules/:id   — wired in Issue 4
-// PUT    /api/rules/:id   — wired in Issue 4
+router.get('/',         getAll);
+router.get('/:id',      getOne);
+router.post('/',        validate(createRuleSchema), create);
+router.put('/:id',      validate(updateRuleSchema), update);
+router.patch('/:id',    validate(toggleRuleSchema), toggle);
+router.delete('/:id',   remove);
 
 export default router;

--- a/backend/src/schemas/rule.schema.ts
+++ b/backend/src/schemas/rule.schema.ts
@@ -1,1 +1,25 @@
-// Rule schema
+import { z } from 'zod';
+
+const ruleTypes    = ['threshold', 'velocity', 'temporal'] as const;
+const operators    = ['gt', 'lt', 'gte', 'lte', 'eq', 'neq', 'in', 'not_in', 'range', 'regex'] as const;
+
+export const createRuleSchema = z.object({
+  rule_name:       z.string().min(1,  { message: 'rule_name is required' }),
+  description:     z.string().optional(),
+  rule_type:       z.enum(ruleTypes,  { message: 'rule_type must be threshold, velocity, or temporal' }),
+  field_name:      z.string().min(1,  { message: 'field_name is required' }),
+  operator:        z.enum(operators,  { message: 'invalid operator' }),
+  threshold_value: z.string().min(1,  { message: 'threshold_value is required' }),
+  weight:          z.number().int().min(1).max(100, { message: 'weight must be between 1 and 100' }),
+  priority:        z.number().int().min(1).optional().default(10),
+});
+
+export const updateRuleSchema = createRuleSchema.partial();
+
+export const toggleRuleSchema = z.object({
+  is_active: z.boolean({ message: 'is_active must be a boolean' }),
+});
+
+export type CreateRuleDTO  = z.infer<typeof createRuleSchema>;
+export type UpdateRuleDTO  = z.infer<typeof updateRuleSchema>;
+export type ToggleRuleDTO  = z.infer<typeof toggleRuleSchema>;

--- a/backend/src/services/rules.service.ts
+++ b/backend/src/services/rules.service.ts
@@ -1,28 +1,98 @@
 import pool from '../db/client';
+import { FraudRule } from '../types/rule.types';
+import { CreateRuleDTO, UpdateRuleDTO, ToggleRuleDTO } from '../schemas/rule.schema';
 
-// GET all active rules
-export const getActiveRules = async () => {
-  const result = await pool.query(
-    `SELECT * FROM fraud_rules WHERE is_active = true ORDER BY created_at DESC`
+// GET all rules (active + inactive), ordered by priority
+export async function getAllRules(): Promise<FraudRule[]> {
+  const result = await pool.query<FraudRule>(
+    `SELECT rule_id, rule_name, description, rule_type, field_name, operator,
+            threshold_value, weight, priority, is_active, created_by, created_at, updated_at
+     FROM fraud_rules
+     ORDER BY priority ASC, created_at DESC`
   );
   return result.rows;
-};
+}
 
-// CREATE a new rule
-export const createRule = async (rule: {
-  name: string;
-  description: string;
-  type: string;
-  field: string;
-  operator: string;
-  value: number;
-  weight: number;
-}) => {
-  const result = await pool.query(
-    `INSERT INTO fraud_rules (name, description, type, field, operator, value, weight)
-     VALUES ($1, $2, $3, $4, $5, $6, $7)
-     RETURNING *`,
-    [rule.name, rule.description, rule.type, rule.field, rule.operator, rule.value, rule.weight]
+// GET one rule by ID
+export async function getRuleById(ruleId: string): Promise<FraudRule | null> {
+  const result = await pool.query<FraudRule>(
+    `SELECT rule_id, rule_name, description, rule_type, field_name, operator,
+            threshold_value, weight, priority, is_active, created_by, created_at, updated_at
+     FROM fraud_rules
+     WHERE rule_id = $1`,
+    [ruleId]
+  );
+  return result.rows[0] ?? null;
+}
+
+// POST create a new rule
+export async function createRule(data: CreateRuleDTO): Promise<FraudRule> {
+  const result = await pool.query<FraudRule>(
+    `INSERT INTO fraud_rules
+       (rule_name, description, rule_type, field_name, operator, threshold_value, weight, priority)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     RETURNING rule_id, rule_name, description, rule_type, field_name, operator,
+               threshold_value, weight, priority, is_active, created_by, created_at, updated_at`,
+    [
+      data.rule_name,
+      data.description ?? null,
+      data.rule_type,
+      data.field_name,
+      data.operator,
+      data.threshold_value,
+      data.weight,
+      data.priority ?? 10,
+    ]
   );
   return result.rows[0];
-};
+}
+
+// PUT update an existing rule's fields
+export async function updateRule(ruleId: string, data: UpdateRuleDTO): Promise<FraudRule | null> {
+  const fields: string[] = [];
+  const values: unknown[] = [];
+  let idx = 1;
+
+  if (data.rule_name       !== undefined) { fields.push(`rule_name = $${idx++}`);       values.push(data.rule_name); }
+  if (data.description     !== undefined) { fields.push(`description = $${idx++}`);     values.push(data.description); }
+  if (data.rule_type       !== undefined) { fields.push(`rule_type = $${idx++}`);       values.push(data.rule_type); }
+  if (data.field_name      !== undefined) { fields.push(`field_name = $${idx++}`);      values.push(data.field_name); }
+  if (data.operator        !== undefined) { fields.push(`operator = $${idx++}`);        values.push(data.operator); }
+  if (data.threshold_value !== undefined) { fields.push(`threshold_value = $${idx++}`); values.push(data.threshold_value); }
+  if (data.weight          !== undefined) { fields.push(`weight = $${idx++}`);          values.push(data.weight); }
+  if (data.priority        !== undefined) { fields.push(`priority = $${idx++}`);        values.push(data.priority); }
+
+  if (fields.length === 0) return getRuleById(ruleId);
+
+  fields.push(`updated_at = NOW()`);
+  values.push(ruleId);
+
+  const result = await pool.query<FraudRule>(
+    `UPDATE fraud_rules SET ${fields.join(', ')} WHERE rule_id = $${idx}
+     RETURNING rule_id, rule_name, description, rule_type, field_name, operator,
+               threshold_value, weight, priority, is_active, created_by, created_at, updated_at`,
+    values
+  );
+  return result.rows[0] ?? null;
+}
+
+// PATCH toggle is_active (enable / disable)
+export async function toggleRule(ruleId: string, data: ToggleRuleDTO): Promise<FraudRule | null> {
+  const result = await pool.query<FraudRule>(
+    `UPDATE fraud_rules SET is_active = $1, updated_at = NOW()
+     WHERE rule_id = $2
+     RETURNING rule_id, rule_name, description, rule_type, field_name, operator,
+               threshold_value, weight, priority, is_active, created_by, created_at, updated_at`,
+    [data.is_active, ruleId]
+  );
+  return result.rows[0] ?? null;
+}
+
+// DELETE a rule permanently
+export async function deleteRule(ruleId: string): Promise<boolean> {
+  const result = await pool.query(
+    `DELETE FROM fraud_rules WHERE rule_id = $1`,
+    [ruleId]
+  );
+  return (result.rowCount ?? 0) > 0;
+}


### PR DESCRIPTION
Implements #26

The existing `rules.service.ts` was partially implemented but completely broken - it used the wrong column names (name, type, field, value) that don't exist in the actual database schema. Calling any rule endpoint would have crashed the server at runtime.

This rewrites all four layers from scratch aligned to the real schema (rule_name, rule_type, field_name, threshold_value, weight, priority).

The API now supports the full lifecycle of a fraud rule. GET all rules returns every rule ordered by priority. GET by ID fetches a single rule. POST creates a new rule with full Zod validation on all fields including the operator and rule_type enums. PUT does a partial update - only the fields sent in the request body are updated, nothing else is touched. PATCH toggles `is_active` to enable or disable a rule without modifying anything else. DELETE removes a rule permanently.

Duplicate rule names return a 409, missing rules return a 404, and all invalid request bodies are caught by the validate middleware before reaching the controller. TypeScript compiles with zero errors.