### PR TITLE
Implement simulate and results API endpoints with service and control…

### DIFF
--- a/backend/src/api/controllers/results.controller.ts
+++ b/backend/src/api/controllers/results.controller.ts
@@ -1,1 +1,33 @@
-// Results controller
+import { Request, Response, NextFunction } from 'express';
+import { getResults, getResultByTxId } from '../../services/results.service';
+
+export async function list(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const limit    = Math.min(parseInt(req.query.limit  as string) || 20, 100);
+    const offset   = parseInt(req.query.offset as string) || 0;
+    const decision = req.query.decision as string | undefined;
+
+    const { results, total } = await getResults(limit, offset, decision);
+
+    res.status(200).json({
+      success: true,
+      data:    results,
+      meta:    { total, limit, offset },
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getOne(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const result = await getResultByTxId(req.params.txId);
+    if (!result) {
+      res.status(404).json({ success: false, error: 'Evaluation result not found' });
+      return;
+    }
+    res.status(200).json({ success: true, data: result });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/api/controllers/simulate.controller.ts
+++ b/backend/src/api/controllers/simulate.controller.ts
@@ -1,1 +1,17 @@
-// Simulate controller
+import { Request, Response, NextFunction } from 'express';
+import { simulateTransaction } from '../../services/simulate.service';
+import { SimulateInputDTO } from '../../schemas/simulate.schema';
+
+export async function simulate(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const input  = req.body as SimulateInputDTO;
+    const result = await simulateTransaction(input);
+    res.status(200).json({ success: true, data: result });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/backend/src/api/routes/results.routes.ts
+++ b/backend/src/api/routes/results.routes.ts
@@ -1,8 +1,12 @@
 import { Router } from 'express';
+import { list, getOne } from '../controllers/results.controller';
 
 const router = Router();
 
-// GET /api/results     — wired in Issue 5
-// GET /api/results/:id — wired in Issue 5
+// GET /api/results?limit=20&offset=0&decision=BLOCK
+router.get('/', list);
+
+// GET /api/results/:txId
+router.get('/:txId', getOne);
 
 export default router;

--- a/backend/src/api/routes/simulate.routes.ts
+++ b/backend/src/api/routes/simulate.routes.ts
@@ -1,7 +1,11 @@
 import { Router } from 'express';
+import { validate } from '../middlewares/validate.middleware';
+import { simulateInputSchema } from '../../schemas/simulate.schema';
+import { simulate } from '../controllers/simulate.controller';
 
 const router = Router();
 
-// POST /api/simulate — wired in Issue 5
+// POST /api/simulate
+router.post('/', validate(simulateInputSchema), simulate);
 
 export default router;

--- a/backend/src/schemas/simulate.schema.ts
+++ b/backend/src/schemas/simulate.schema.ts
@@ -1,1 +1,11 @@
-// Simulate schema
+import { z } from 'zod';
+
+export const simulateInputSchema = z.object({
+  user_id:          z.string().uuid({ message: 'user_id must be a valid UUID' }),
+  amount:           z.number().positive({ message: 'amount must be greater than 0' }),
+  location:         z.string().min(1, { message: 'location is required' }),
+  device_id:        z.string().min(1, { message: 'device_id is required' }),
+  transaction_time: z.string().datetime({ message: 'transaction_time must be an ISO 8601 datetime' }).optional(),
+});
+
+export type SimulateInputDTO = z.infer<typeof simulateInputSchema>;

--- a/backend/src/services/results.service.ts
+++ b/backend/src/services/results.service.ts
@@ -1,1 +1,87 @@
-// Results service implementation
+import pool from '../db/client';
+
+export interface EvaluationSummary {
+  id:                 string;
+  tx_id:              string;
+  risk_score:         number;
+  decision:           string;
+  is_alert_generated: boolean;
+  evaluation_time:    Date;
+  triggered_rules:    { rule_name: string; rule_type: string; reason: string }[];
+}
+
+// GET paginated list of all evaluation results
+export async function getResults(
+  limit = 20,
+  offset = 0,
+  decision?: string
+): Promise<{ results: EvaluationSummary[]; total: number }> {
+  const conditions: string[] = [];
+  const params: unknown[]    = [];
+  let idx = 1;
+
+  if (decision) {
+    conditions.push(`rl.decision = $${idx++}`);
+    params.push(decision.toUpperCase());
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+  const countResult = await pool.query<{ count: string }>(
+    `SELECT COUNT(*) FROM risk_logs rl ${where}`,
+    params
+  );
+  const total = parseInt(countResult.rows[0].count, 10);
+
+  params.push(limit, offset);
+
+  const result = await pool.query<EvaluationSummary>(
+    `SELECT
+       rl.id, rl.tx_id, rl.risk_score, rl.decision,
+       rl.is_alert_generated, rl.evaluation_time,
+       COALESCE(
+         JSON_AGG(
+           JSON_BUILD_OBJECT(
+             'rule_name', ret.rule_name,
+             'rule_type', ret.rule_type,
+             'reason',    ret.reason
+           )
+         ) FILTER (WHERE ret.rule_name IS NOT NULL),
+         '[]'
+       ) AS triggered_rules
+     FROM risk_logs rl
+     LEFT JOIN rule_evaluation_trace ret ON ret.tx_id = rl.tx_id
+     ${where}
+     GROUP BY rl.id
+     ORDER BY rl.evaluation_time DESC
+     LIMIT $${idx++} OFFSET $${idx++}`,
+    params
+  );
+
+  return { results: result.rows, total };
+}
+
+// GET single evaluation result by tx_id
+export async function getResultByTxId(txId: string): Promise<EvaluationSummary | null> {
+  const result = await pool.query<EvaluationSummary>(
+    `SELECT
+       rl.id, rl.tx_id, rl.risk_score, rl.decision,
+       rl.is_alert_generated, rl.evaluation_time,
+       COALESCE(
+         JSON_AGG(
+           JSON_BUILD_OBJECT(
+             'rule_name', ret.rule_name,
+             'rule_type', ret.rule_type,
+             'reason',    ret.reason
+           )
+         ) FILTER (WHERE ret.rule_name IS NOT NULL),
+         '[]'
+       ) AS triggered_rules
+     FROM risk_logs rl
+     LEFT JOIN rule_evaluation_trace ret ON ret.tx_id = rl.tx_id
+     WHERE rl.tx_id = $1
+     GROUP BY rl.id`,
+    [txId]
+  );
+  return result.rows[0] ?? null;
+}

--- a/backend/src/services/simulate.service.ts
+++ b/backend/src/services/simulate.service.ts
@@ -1,1 +1,63 @@
-// Simulate service implementation
+import { randomUUID } from 'crypto';
+import { Transaction } from '../types/transaction.types';
+import { SimulateInputDTO } from '../schemas/simulate.schema';
+import { loadActiveRules } from '../engine/ruleLoader';
+import { getVelocityData } from '../engine/velocityChecker';
+import { evaluateRule } from '../engine/ruleEvaluator';
+import { aggregateScore, makeDecision } from '../engine/scoreAggregator';
+import { generateExplanation, ExplainableOutput } from '../engine/explainabilityGenerator';
+import { EvaluationResult, TriggeredRule } from '../types/decision.types';
+import { logger } from '../utils/logger';
+
+const ALERT_SCORE_THRESHOLD = 70;
+
+export async function simulateTransaction(input: SimulateInputDTO): Promise<ExplainableOutput> {
+  // Build a transient Transaction object — never written to the DB
+  const tx: Transaction = {
+    tx_id:            randomUUID(),
+    user_id:          input.user_id,
+    amount:           input.amount,
+    location:         input.location,
+    device_id:        input.device_id,
+    transaction_time: input.transaction_time ? new Date(input.transaction_time) : new Date(),
+    is_simulation:    true,   // velocityChecker excludes simulations from historical counts
+    created_at:       new Date(),
+  };
+
+  const rules = await loadActiveRules();
+
+  // Velocity data still uses real history so the simulation reflects actual user context
+  const velocityData = await getVelocityData(tx.user_id, tx.transaction_time);
+
+  logger.info('Simulating transaction', { tx_id: tx.tx_id, rules_loaded: rules.length });
+
+  const triggeredRules: TriggeredRule[] = [];
+
+  for (const rule of rules) {
+    const result = evaluateRule(rule, tx, velocityData);
+    if (result.triggered) {
+      triggeredRules.push({
+        rule_id:        rule.rule_id,
+        rule_name:      rule.rule_name,
+        rule_type:      rule.rule_type,
+        weight_applied: rule.weight,
+        reason:         result.reason,
+      });
+    }
+  }
+
+  const risk_score         = aggregateScore(triggeredRules);
+  const decision           = makeDecision(risk_score);
+  const is_alert_generated = risk_score >= ALERT_SCORE_THRESHOLD;
+
+  const evaluationResult: EvaluationResult = {
+    tx_id:           tx.tx_id,
+    risk_score,
+    decision,
+    triggered_rules:  triggeredRules,
+    evaluation_time:  new Date(),
+    is_alert_generated,
+  };
+
+  return generateExplanation(evaluationResult);
+}


### PR DESCRIPTION
Closes #27 

This adds the two remaining backend API surfaces - simulation and evaluation history.

The simulate endpoint (`POST /api/simulate`) runs a transaction through the full fraud detection engine without writing anything to the database. It builds a transient Transaction object in memory with `is_simulation: true` and generates a fresh UUID using Node's built-in `crypto.randomUUID()`. The velocity checker already excludes simulated transactions from historical counts by design, so the simulation reflects real user context without polluting it. The entire engine pipeline runs - rule loading, velocity data, rule evaluation, score aggregation, explainability - and the result is returned directly to the client. Nothing is persisted. This is the endpoint that powers the consumer-facing payment verification dashboard discussed in the feature proposal.

The results endpoint (`GET /api/results`) returns paginated evaluation history from `risk_logs` joined with `rule_evaluation_trace`, so each result includes the triggered rules and reasons. Supports `?limit`, `?offset`, and `?decision=BLOCK` query params for filtering. `GET /api/results/:txId` fetches a single result by transaction ID.

TypeScript compiles with zero errors across all seven new files.
