### PR TITLE
 Add seed data for fraud rules and sample transactions

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,9 @@
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "start": "ts-node src/index.ts",
     "migrate": "ts-node src/db/migrate.ts",
+    "seed:rules": "ts-node src/db/seeds/rules.seed.ts",
+    "seed:transactions": "ts-node src/db/seeds/transactions.seed.ts",
+    "seed": "npm run seed:rules && npm run seed:transactions",
     "test": "jest --runInBand"
   },
   "dependencies": {

--- a/backend/src/db/seeds/rules.seed.ts
+++ b/backend/src/db/seeds/rules.seed.ts
@@ -1,1 +1,109 @@
-// Rules seed data
+import pool from '../client';
+
+const rules = [
+  // --- Threshold rules ---
+  {
+    rule_name:       'High Amount Block',
+    description:     'Blocks transactions above ₹50,000 — high risk of fraud',
+    rule_type:       'threshold',
+    field_name:      'amount',
+    operator:        'gt',
+    threshold_value: '50000',
+    weight:          70,
+    priority:        1,
+  },
+  {
+    rule_name:       'Medium Amount Review',
+    description:     'Flags transactions above ₹10,000 for manual review',
+    rule_type:       'threshold',
+    field_name:      'amount',
+    operator:        'gt',
+    threshold_value: '10000',
+    weight:          30,
+    priority:        2,
+  },
+  {
+    rule_name:       'Safe Amount',
+    description:     'Low-value transactions under ₹5,000 are treated as low risk',
+    rule_type:       'threshold',
+    field_name:      'amount',
+    operator:        'lte',
+    threshold_value: '5000',
+    weight:          10,
+    priority:        3,
+  },
+
+  // --- Temporal rules ---
+  {
+    rule_name:       'Night Hour Transaction',
+    description:     'Flags transactions between 10 PM and 5 AM UTC as suspicious',
+    rule_type:       'temporal',
+    field_name:      'hour_of_day',
+    operator:        'in',
+    threshold_value: '0,1,2,3,4,5,22,23',
+    weight:          40,
+    priority:        4,
+  },
+
+  // --- Velocity rules ---
+  {
+    rule_name:       'High Transaction Frequency 1h',
+    description:     'More than 5 transactions in the last hour from the same user',
+    rule_type:       'velocity',
+    field_name:      'tx_count_1h',
+    operator:        'gt',
+    threshold_value: '5',
+    weight:          50,
+    priority:        5,
+  },
+  {
+    rule_name:       'High Spend 1h',
+    description:     'Total spend exceeds ₹10,000 within the last hour',
+    rule_type:       'velocity',
+    field_name:      'tx_amount_1h',
+    operator:        'gt',
+    threshold_value: '10000',
+    weight:          30,
+    priority:        6,
+  },
+  {
+    rule_name:       'High Transaction Frequency 24h',
+    description:     'More than 15 transactions in the last 24 hours from the same user',
+    rule_type:       'velocity',
+    field_name:      'tx_count_24h',
+    operator:        'gt',
+    threshold_value: '15',
+    weight:          20,
+    priority:        7,
+  },
+];
+
+async function seedRules() {
+  console.log('Seeding fraud rules...');
+
+  for (const rule of rules) {
+    await pool.query(
+      `INSERT INTO fraud_rules
+         (rule_name, description, rule_type, field_name, operator, threshold_value, weight, priority)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       ON CONFLICT (rule_name) DO NOTHING`,
+      [
+        rule.rule_name,
+        rule.description,
+        rule.rule_type,
+        rule.field_name,
+        rule.operator,
+        rule.threshold_value,
+        rule.weight,
+        rule.priority,
+      ]
+    );
+    console.log(`  Seeded rule: ${rule.rule_name}`);
+  }
+
+  console.log(`Seeded ${rules.length} fraud rules.`);
+}
+
+seedRules()
+  .catch(err => { console.error('Rule seeding failed:', err); process.exit(1); })
+  .finally(() => pool.end());

--- a/backend/src/db/seeds/transactions.seed.ts
+++ b/backend/src/db/seeds/transactions.seed.ts
@@ -1,1 +1,125 @@
-// Transactions seed data
+import pool from '../client';
+
+// Seed users first so the foreign key on transactions is satisfied
+const users = [
+  { user_id: 'a1b2c3d4-0001-0001-0001-000000000001', email: 'alice@example.com',   name: 'Alice' },
+  { user_id: 'a1b2c3d4-0002-0002-0002-000000000002', email: 'bob@example.com',     name: 'Bob' },
+  { user_id: 'a1b2c3d4-0003-0003-0003-000000000003', email: 'charlie@example.com', name: 'Charlie' },
+];
+
+// Transactions designed to exercise every decision outcome
+// Each group maps to one of the three scenario test files
+const transactions = [
+
+  // --- Scenario: Large Amount → BLOCK (High Amount Block weight 70 + Medium Amount Review weight 30 = 100) ---
+  {
+    user_id:          'a1b2c3d4-0001-0001-0001-000000000001',
+    amount:           85000,
+    location:         'US',
+    device_id:        'device-alice-001',
+    transaction_time: '2026-04-12T14:00:00Z',  // 2 PM — normal hours, only amount rules fire
+    is_simulation:    false,
+    label:            'BLOCK — large amount (₹85,000)',
+  },
+
+  // --- Scenario: Large Amount → ALLOW (Safe Amount weight 10, score < 30) ---
+  {
+    user_id:          'a1b2c3d4-0001-0001-0001-000000000001',
+    amount:           3000,
+    location:         'US',
+    device_id:        'device-alice-001',
+    transaction_time: '2026-04-12T11:00:00Z',
+    is_simulation:    false,
+    label:            'ALLOW — safe amount (₹3,000)',
+  },
+
+  // --- Scenario: Night Time → BLOCK (Night Hour weight 40 + Medium Amount weight 30 = 70) ---
+  {
+    user_id:          'a1b2c3d4-0002-0002-0002-000000000002',
+    amount:           8000,
+    location:         'US',
+    device_id:        'device-bob-001',
+    transaction_time: '2026-04-12T02:30:00Z',  // 2:30 AM UTC — night hour rule fires
+    is_simulation:    false,
+    label:            'BLOCK — night transaction with medium amount',
+  },
+
+  // --- Scenario: Night Time → REVIEW (only Medium Amount weight 30 fires — daytime) ---
+  {
+    user_id:          'a1b2c3d4-0002-0002-0002-000000000002',
+    amount:           8000,
+    location:         'US',
+    device_id:        'device-bob-001',
+    transaction_time: '2026-04-12T10:00:00Z',  // 10 AM UTC — no night rule, only amount rule
+    is_simulation:    false,
+    label:            'REVIEW — daytime medium amount',
+  },
+
+  // --- Scenario: Rapid Velocity — base transaction (velocity data provided separately in tests) ---
+  {
+    user_id:          'a1b2c3d4-0003-0003-0003-000000000003',
+    amount:           2000,
+    location:         'IN',
+    device_id:        'device-charlie-001',
+    transaction_time: '2026-04-12T14:00:00Z',
+    is_simulation:    false,
+    label:            'base transaction — BLOCK when velocity is high',
+  },
+
+  // --- Simulation example — safe, used for frontend demo ---
+  {
+    user_id:          'a1b2c3d4-0001-0001-0001-000000000001',
+    amount:           500,
+    location:         'IN',
+    device_id:        'device-alice-mobile',
+    transaction_time: '2026-04-12T09:00:00Z',
+    is_simulation:    true,
+    label:            'ALLOW — simulation, low amount daytime',
+  },
+];
+
+async function seedUsers() {
+  for (const user of users) {
+    await pool.query(
+      `INSERT INTO users (user_id, email, name)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (user_id) DO NOTHING`,
+      [user.user_id, user.email, user.name]
+    );
+    console.log(`  Seeded user: ${user.name}`);
+  }
+}
+
+async function seedTransactions() {
+  console.log('Seeding transactions...');
+
+  for (const tx of transactions) {
+    await pool.query(
+      `INSERT INTO transactions (user_id, amount, location, device_id, transaction_time, is_simulation)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       ON CONFLICT DO NOTHING`,
+      [
+        tx.user_id,
+        tx.amount,
+        tx.location,
+        tx.device_id,
+        new Date(tx.transaction_time),
+        tx.is_simulation,
+      ]
+    );
+    console.log(`  Seeded tx: ${tx.label}`);
+  }
+
+  console.log(`Seeded ${transactions.length} transactions.`);
+}
+
+async function run() {
+  console.log('Seeding users...');
+  await seedUsers();
+  console.log(`Seeded ${users.length} users.`);
+  await seedTransactions();
+}
+
+run()
+  .catch(err => { console.error('Transaction seeding failed:', err); process.exit(1); })
+  .finally(() => pool.end());


### PR DESCRIPTION
closes #28 

Both seed files were empty stubs. Without seed data the system cannot be demoed or tested end-to-end through the API since there are no rules to evaluate against and no users to satisfy the foreign key on transactions.

`rules.seed.ts` inserts 7 fraud rules covering all three rule types the engine supports. The rules and their exact thresholds, weights, operators, and priorities are derived directly from the three scenario test files your partner wrote, so the seeded rules produce the same decisions those tests assert. High Amount Block (weight 70, gt 50000), Medium Amount Review (weight 30, gt 10000), Safe Amount (weight 10, lte 5000), Night Hour Transaction (weight 40, in 0-5 and 22-23), High Transaction Frequency 1h (weight 50, gt 5), High Spend 1h (weight 30, gt 10000), High Transaction Frequency 24h (weight 20, gt 15). All inserts use ON CONFLICT (rule_name) DO NOTHING so running the seed twice is safe.

`transactions.seed.ts` first seeds three users to satisfy the foreign key, then inserts six sample transactions - one for each expected outcome across the three scenarios: two large-amount transactions (BLOCK at ₹85k, ALLOW at ₹3k), two night-vs-day transactions (BLOCK at 2:30 AM, REVIEW at 10 AM with the same amount), one base velocity transaction, and one simulation entry for the frontend demo.

Three npm scripts added: seed:rules, seed:transactions, and seed which runs both in order after migrations.