### PR TITLE
test: add integration tests for evaluate, rules, and results APIs

### DIFF
--- a/backend/src/services/transaction.service.ts
+++ b/backend/src/services/transaction.service.ts
@@ -41,8 +41,8 @@ async function persistEvaluation(output: ExplainableOutput): Promise<void> {
 
   if (output.triggered_rules.length > 0) {
     const values = output.triggered_rules.map((_, i) => {
-      const base = i * 5;
-      return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5})`;
+      const base = i * 6;
+      return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6})`;
     }).join(', ');
 
     const params = output.triggered_rules.flatMap(r => [
@@ -50,11 +50,12 @@ async function persistEvaluation(output: ExplainableOutput): Promise<void> {
       r.rule_id,
       r.rule_name,
       r.rule_type,
+      r.weight_applied,
       r.reason,
     ]);
 
     await pool.query(
-      `INSERT INTO rule_evaluation_trace (tx_id, rule_id, rule_name, rule_type, reason)
+      `INSERT INTO rule_evaluation_trace (tx_id, rule_id, rule_name, rule_type, weight_applied, reason)
        VALUES ${values}`,
       params
     );

--- a/backend/tests/integration/results.api.test.ts
+++ b/backend/tests/integration/results.api.test.ts
@@ -1,1 +1,236 @@
-// Results API tests
+import request from 'supertest';
+import pool from '../../src/db/client';
+import app from '../../src/app';
+
+const EVALUATE = '/api/transactions/evaluate';
+const BASE     = '/api/results';
+
+let testUserId: string;
+let blockTxId:  string;
+let allowTxId:  string;
+
+// Explicit daytime to avoid the Night Hour temporal rule (10PM–5AM UTC)
+const DAYTIME = '2026-06-16T10:00:00.000Z';
+
+beforeAll(async () => {
+  // Create a dedicated test user — cascade delete cleans up everything on teardown
+  const { rows } = await pool.query<{ user_id: string }>(
+    `INSERT INTO users (name, email) VALUES ($1, $2) RETURNING user_id`,
+    ['Results Integration User', `results-integration-${Date.now()}@test.com`]
+  );
+  testUserId = rows[0].user_id;
+
+  // Evaluate a high-risk transaction → should produce BLOCK (amount 100,000 triggers
+  // "High Amount Block" weight ≥ 70, putting score at BLOCK threshold)
+  const blockRes = await request(app).post(EVALUATE).send({
+    user_id:          testUserId,
+    amount:           100_000,
+    location:         'RU',
+    device_id:        'device-results-test',
+    transaction_time: DAYTIME,
+  });
+  blockTxId = blockRes.body.data.tx_id;
+
+  // Evaluate a low-risk transaction → ALLOW
+  const allowRes = await request(app).post(EVALUATE).send({
+    user_id:          testUserId,
+    amount:           100,
+    location:         'IN',
+    device_id:        'device-results-test',
+    transaction_time: DAYTIME,
+  });
+  allowTxId = allowRes.body.data.tx_id;
+});
+
+afterAll(async () => {
+  // Deleting the user cascades: transactions → risk_logs + rule_evaluation_trace
+  await pool.query(`DELETE FROM users WHERE user_id = $1`, [testUserId]);
+  await pool.end();
+});
+
+// ── GET /api/results ───────────────────────────────────────────────────────────
+
+describe('GET /api/results', () => {
+
+  test('returns 200 with success: true', async () => {
+    const res = await request(app).get(BASE);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  test('data is an array', async () => {
+    const res = await request(app).get(BASE);
+    expect(Array.isArray(res.body.data)).toBe(true);
+  });
+
+  test('meta contains total, limit, offset', async () => {
+    const res = await request(app).get(BASE);
+    expect(res.body.meta).toHaveProperty('total');
+    expect(res.body.meta).toHaveProperty('limit');
+    expect(res.body.meta).toHaveProperty('offset');
+  });
+
+  test('total is a non-negative integer', async () => {
+    const res = await request(app).get(BASE);
+    expect(typeof res.body.meta.total).toBe('number');
+    expect(res.body.meta.total).toBeGreaterThanOrEqual(0);
+  });
+
+  test('results include the evaluated test transactions', async () => {
+    const res = await request(app).get(BASE);
+    const txIds = res.body.data.map((r: { tx_id: string }) => r.tx_id);
+    expect(txIds).toContain(blockTxId);
+    expect(txIds).toContain(allowTxId);
+  });
+
+  test('each result has the required fields', async () => {
+    const res = await request(app).get(BASE);
+    const result = res.body.data[0];
+    expect(result).toHaveProperty('tx_id');
+    expect(result).toHaveProperty('decision');
+    expect(result).toHaveProperty('risk_score');
+    expect(result).toHaveProperty('is_alert_generated');
+    expect(result).toHaveProperty('evaluation_time');
+    expect(result).toHaveProperty('triggered_rules');
+  });
+
+  test('triggered_rules is an array on each result', async () => {
+    const res = await request(app).get(BASE);
+    for (const result of res.body.data) {
+      expect(Array.isArray(result.triggered_rules)).toBe(true);
+    }
+  });
+
+  test('decision values are valid (ALLOW, REVIEW, or BLOCK)', async () => {
+    const res = await request(app).get(BASE);
+    for (const result of res.body.data) {
+      expect(['ALLOW', 'REVIEW', 'BLOCK']).toContain(result.decision);
+    }
+  });
+
+  test('results are ordered by evaluation_time descending (most recent first)', async () => {
+    const res = await request(app).get(BASE);
+    const times = res.body.data.map((r: { evaluation_time: string }) =>
+      new Date(r.evaluation_time).getTime()
+    );
+    for (let i = 1; i < times.length; i++) {
+      expect(times[i - 1]).toBeGreaterThanOrEqual(times[i]);
+    }
+  });
+});
+
+// ── GET /api/results — pagination ──────────────────────────────────────────────
+
+describe('GET /api/results — pagination', () => {
+
+  test('limit=1 returns exactly one result', async () => {
+    const res = await request(app).get(`${BASE}?limit=1`);
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBe(1);
+    expect(res.body.meta.limit).toBe(1);
+  });
+
+  test('offset skips results correctly', async () => {
+    const page1 = await request(app).get(`${BASE}?limit=1&offset=0`);
+    const page2 = await request(app).get(`${BASE}?limit=1&offset=1`);
+    expect(page1.body.data[0].tx_id).not.toBe(page2.body.data[0].tx_id);
+  });
+
+  test('limit is capped at 100 by the server', async () => {
+    const res = await request(app).get(`${BASE}?limit=999`);
+    expect(res.body.data.length).toBeLessThanOrEqual(100);
+  });
+});
+
+// ── GET /api/results — decision filter ────────────────────────────────────────
+
+describe('GET /api/results — decision filter', () => {
+
+  test('?decision=BLOCK returns only BLOCK results', async () => {
+    const res = await request(app).get(`${BASE}?decision=BLOCK`);
+    expect(res.status).toBe(200);
+    for (const result of res.body.data) {
+      expect(result.decision).toBe('BLOCK');
+    }
+  });
+
+  test('?decision=ALLOW returns only ALLOW results', async () => {
+    const res = await request(app).get(`${BASE}?decision=ALLOW`);
+    expect(res.status).toBe(200);
+    for (const result of res.body.data) {
+      expect(result.decision).toBe('ALLOW');
+    }
+  });
+
+  test('BLOCK filter result set includes our high-risk transaction', async () => {
+    const res = await request(app).get(`${BASE}?decision=BLOCK`);
+    const txIds = res.body.data.map((r: { tx_id: string }) => r.tx_id);
+    expect(txIds).toContain(blockTxId);
+  });
+
+  test('ALLOW filter result set includes our low-risk transaction', async () => {
+    const res = await request(app).get(`${BASE}?decision=ALLOW`);
+    const txIds = res.body.data.map((r: { tx_id: string }) => r.tx_id);
+    expect(txIds).toContain(allowTxId);
+  });
+
+  test('decision filter is case-insensitive', async () => {
+    const res = await request(app).get(`${BASE}?decision=block`);
+    expect(res.status).toBe(200);
+    for (const result of res.body.data) {
+      expect(result.decision).toBe('BLOCK');
+    }
+  });
+});
+
+// ── GET /api/results/:txId ─────────────────────────────────────────────────────
+
+describe('GET /api/results/:txId', () => {
+
+  test('returns 200 with the correct result for a known tx_id', async () => {
+    const res = await request(app).get(`${BASE}/${blockTxId}`);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.tx_id).toBe(blockTxId);
+  });
+
+  test('returned result has all required fields', async () => {
+    const res = await request(app).get(`${BASE}/${blockTxId}`);
+    const { data } = res.body;
+    expect(data).toHaveProperty('tx_id');
+    expect(data).toHaveProperty('decision');
+    expect(data).toHaveProperty('risk_score');
+    expect(data).toHaveProperty('is_alert_generated');
+    expect(data).toHaveProperty('evaluation_time');
+    expect(data).toHaveProperty('triggered_rules');
+  });
+
+  test('BLOCK result has is_alert_generated: true (score ≥ 70)', async () => {
+    const res = await request(app).get(`${BASE}/${blockTxId}`);
+    expect(res.body.data.decision).toBe('BLOCK');
+    expect(res.body.data.is_alert_generated).toBe(true);
+    expect(res.body.data.risk_score).toBeGreaterThanOrEqual(70);
+  });
+
+  test('ALLOW result has is_alert_generated: false (score < 70)', async () => {
+    const res = await request(app).get(`${BASE}/${allowTxId}`);
+    expect(res.body.data.decision).toBe('ALLOW');
+    expect(res.body.data.is_alert_generated).toBe(false);
+  });
+
+  test('triggered_rules contains rule entries with correct shape', async () => {
+    const res = await request(app).get(`${BASE}/${blockTxId}`);
+    const rule = res.body.data.triggered_rules[0];
+    if (rule) {
+      expect(rule).toHaveProperty('rule_name');
+      expect(rule).toHaveProperty('rule_type');
+      expect(rule).toHaveProperty('reason');
+    }
+  });
+
+  test('non-existent tx_id → 404', async () => {
+    const res = await request(app).get(`${BASE}/00000000-0000-0000-0000-000000000000`);
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
+  });
+});

--- a/backend/tests/integration/rules.api.test.ts
+++ b/backend/tests/integration/rules.api.test.ts
@@ -1,1 +1,297 @@
-// Rules API tests
+import request from 'supertest';
+import pool from '../../src/db/client';
+import app from '../../src/app';
+
+const BASE = '/api/rules';
+
+// Tracks every rule created during tests so afterAll can clean up any leftovers
+const createdRuleIds: string[] = [];
+
+let counter = 0;
+const uniqueName = () => `Integration Test Rule ${Date.now()}-${++counter}`;
+
+const rulePayload = (overrides: Record<string, unknown> = {}) => ({
+  rule_name:       uniqueName(),
+  rule_type:       'threshold',
+  field_name:      'amount',
+  operator:        'gt',
+  threshold_value: '999999',
+  weight:          5,
+  priority:        99,
+  ...overrides,
+});
+
+afterAll(async () => {
+  if (createdRuleIds.length > 0) {
+    await pool.query(
+      `DELETE FROM fraud_rules WHERE rule_id = ANY($1::uuid[])`,
+      [createdRuleIds]
+    );
+  }
+  await pool.end();
+});
+
+// ── GET /api/rules ─────────────────────────────────────────────────────────────
+
+describe('GET /api/rules', () => {
+
+  test('returns 200 with success: true', async () => {
+    const res = await request(app).get(BASE);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  test('data is an array', async () => {
+    const res = await request(app).get(BASE);
+    expect(Array.isArray(res.body.data)).toBe(true);
+  });
+
+  test('each rule has required fields', async () => {
+    const res = await request(app).get(BASE);
+    const rule = res.body.data[0];
+    if (rule) {
+      expect(rule).toHaveProperty('rule_id');
+      expect(rule).toHaveProperty('rule_name');
+      expect(rule).toHaveProperty('rule_type');
+      expect(rule).toHaveProperty('field_name');
+      expect(rule).toHaveProperty('operator');
+      expect(rule).toHaveProperty('threshold_value');
+      expect(rule).toHaveProperty('weight');
+      expect(rule).toHaveProperty('is_active');
+    }
+  });
+});
+
+// ── POST /api/rules ────────────────────────────────────────────────────────────
+
+describe('POST /api/rules', () => {
+
+  test('creates a rule and returns 201 with the new rule', async () => {
+    const body = rulePayload();
+    const res = await request(app).post(BASE).send(body);
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.rule_name).toBe(body.rule_name);
+    createdRuleIds.push(res.body.data.rule_id);
+  });
+
+  test('new rule has a valid UUID as rule_id', async () => {
+    const res = await request(app).post(BASE).send(rulePayload());
+    expect(res.body.data.rule_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    );
+    createdRuleIds.push(res.body.data.rule_id);
+  });
+
+  test('new rule is active by default', async () => {
+    const res = await request(app).post(BASE).send(rulePayload());
+    expect(res.body.data.is_active).toBe(true);
+    createdRuleIds.push(res.body.data.rule_id);
+  });
+
+  test('new rule has created_at and updated_at timestamps', async () => {
+    const res = await request(app).post(BASE).send(rulePayload());
+    expect(res.body.data).toHaveProperty('created_at');
+    expect(res.body.data).toHaveProperty('updated_at');
+    createdRuleIds.push(res.body.data.rule_id);
+  });
+
+  test('optional description is stored when provided', async () => {
+    const res = await request(app).post(BASE).send(rulePayload({ description: 'Test desc' }));
+    expect(res.body.data.description).toBe('Test desc');
+    createdRuleIds.push(res.body.data.rule_id);
+  });
+
+  test('duplicate rule_name → 409', async () => {
+    const name = uniqueName();
+    const first = await request(app).post(BASE).send(rulePayload({ rule_name: name }));
+    createdRuleIds.push(first.body.data.rule_id);
+
+    const second = await request(app).post(BASE).send(rulePayload({ rule_name: name }));
+    expect(second.status).toBe(409);
+    expect(second.body.success).toBe(false);
+  });
+
+  test('missing rule_name → 400', async () => {
+    const { rule_name, ...body } = rulePayload();
+    const res = await request(app).post(BASE).send(body);
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  test('invalid rule_type → 400', async () => {
+    const res = await request(app).post(BASE).send(rulePayload({ rule_type: 'invalid_type' }));
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  test('invalid operator → 400', async () => {
+    const res = await request(app).post(BASE).send(rulePayload({ operator: 'between' }));
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  test('weight above 100 → 400', async () => {
+    const res = await request(app).post(BASE).send(rulePayload({ weight: 101 }));
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  test('weight below 1 → 400', async () => {
+    const res = await request(app).post(BASE).send(rulePayload({ weight: 0 }));
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  test('empty body → 400', async () => {
+    const res = await request(app).post(BASE).send({});
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  test('all supported rule_types are accepted', async () => {
+    for (const rule_type of ['threshold', 'velocity', 'temporal']) {
+      const res = await request(app).post(BASE).send(rulePayload({ rule_type }));
+      expect(res.status).toBe(201);
+      createdRuleIds.push(res.body.data.rule_id);
+    }
+  });
+});
+
+// ── GET /api/rules/:id ─────────────────────────────────────────────────────────
+
+describe('GET /api/rules/:id', () => {
+
+  let ruleId: string;
+  let ruleName: string;
+
+  beforeAll(async () => {
+    const body = rulePayload();
+    ruleName = body.rule_name as string;
+    const res = await request(app).post(BASE).send(body);
+    ruleId = res.body.data.rule_id;
+    createdRuleIds.push(ruleId);
+  });
+
+  test('returns 200 with the correct rule', async () => {
+    const res = await request(app).get(`${BASE}/${ruleId}`);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.rule_id).toBe(ruleId);
+    expect(res.body.data.rule_name).toBe(ruleName);
+  });
+
+  test('non-existent rule_id → 404', async () => {
+    const res = await request(app).get(`${BASE}/00000000-0000-0000-0000-000000000000`);
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
+  });
+});
+
+// ── PUT /api/rules/:id ─────────────────────────────────────────────────────────
+
+describe('PUT /api/rules/:id', () => {
+
+  let ruleId: string;
+
+  beforeAll(async () => {
+    const res = await request(app).post(BASE).send(rulePayload());
+    ruleId = res.body.data.rule_id;
+    createdRuleIds.push(ruleId);
+  });
+
+  test('updates the rule and returns the updated data', async () => {
+    const res = await request(app)
+      .put(`${BASE}/${ruleId}`)
+      .send({ weight: 42, threshold_value: '77777' });
+    expect(res.status).toBe(200);
+    expect(res.body.data.weight).toBe(42);
+    expect(res.body.data.threshold_value).toBe('77777');
+  });
+
+  test('non-existent rule_id → 404', async () => {
+    const res = await request(app)
+      .put(`${BASE}/00000000-0000-0000-0000-000000000000`)
+      .send({ weight: 10 });
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
+  });
+});
+
+// ── PATCH /api/rules/:id ───────────────────────────────────────────────────────
+
+describe('PATCH /api/rules/:id (toggle)', () => {
+
+  let ruleId: string;
+
+  beforeAll(async () => {
+    const res = await request(app).post(BASE).send(rulePayload());
+    ruleId = res.body.data.rule_id;
+    createdRuleIds.push(ruleId);
+  });
+
+  test('disables an active rule', async () => {
+    const res = await request(app)
+      .patch(`${BASE}/${ruleId}`)
+      .send({ is_active: false });
+    expect(res.status).toBe(200);
+    expect(res.body.data.is_active).toBe(false);
+  });
+
+  test('re-enables a disabled rule', async () => {
+    await request(app).patch(`${BASE}/${ruleId}`).send({ is_active: false });
+    const res = await request(app).patch(`${BASE}/${ruleId}`).send({ is_active: true });
+    expect(res.status).toBe(200);
+    expect(res.body.data.is_active).toBe(true);
+  });
+
+  test('missing is_active → 400', async () => {
+    const res = await request(app).patch(`${BASE}/${ruleId}`).send({});
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  test('non-boolean is_active → 400', async () => {
+    const res = await request(app).patch(`${BASE}/${ruleId}`).send({ is_active: 'yes' });
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  test('non-existent rule_id → 404', async () => {
+    const res = await request(app)
+      .patch(`${BASE}/00000000-0000-0000-0000-000000000000`)
+      .send({ is_active: false });
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
+  });
+});
+
+// ── DELETE /api/rules/:id ──────────────────────────────────────────────────────
+
+describe('DELETE /api/rules/:id', () => {
+
+  test('deletes a rule and returns 200', async () => {
+    const created = await request(app).post(BASE).send(rulePayload());
+    const ruleId  = created.body.data.rule_id;
+
+    const res = await request(app).delete(`${BASE}/${ruleId}`);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  test('deleted rule is no longer retrievable', async () => {
+    const created = await request(app).post(BASE).send(rulePayload());
+    const ruleId  = created.body.data.rule_id;
+
+    await request(app).delete(`${BASE}/${ruleId}`);
+
+    const res = await request(app).get(`${BASE}/${ruleId}`);
+    expect(res.status).toBe(404);
+  });
+
+  test('non-existent rule_id → 404', async () => {
+    const res = await request(app).delete(`${BASE}/00000000-0000-0000-0000-000000000000`);
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
+  });
+});

--- a/backend/tests/integration/transaction.api.test.ts
+++ b/backend/tests/integration/transaction.api.test.ts
@@ -1,1 +1,233 @@
-// Transaction API tests
+import request from 'supertest';
+import pool from '../../src/db/client';
+import app from '../../src/app';
+
+const BASE = '/api/transactions/evaluate';
+
+let testUserId: string;
+
+beforeAll(async () => {
+  const { rows } = await pool.query<{ user_id: string }>(
+    `INSERT INTO users (name, email) VALUES ($1, $2) RETURNING user_id`,
+    ['TX Integration User', `tx-integration-${Date.now()}@test.com`]
+  );
+  testUserId = rows[0].user_id;
+});
+
+afterAll(async () => {
+  // Cascades: users → transactions → risk_logs + rule_evaluation_trace
+  await pool.query(`DELETE FROM users WHERE user_id = $1`, [testUserId]);
+  await pool.end();
+});
+
+// Explicit 10 AM UTC to avoid the Night Hour temporal rule (triggers 10PM–5AM)
+const DAYTIME = '2026-06-16T10:00:00.000Z';
+
+const payload = (overrides: Record<string, unknown> = {}) => ({
+  user_id:          testUserId,
+  amount:           500,
+  location:         'IN',
+  device_id:        'device-integration-test',
+  transaction_time: DAYTIME,
+  ...overrides,
+});
+
+// ── Response Shape ─────────────────────────────────────────────────────────────
+
+describe('POST /api/transactions/evaluate — response shape', () => {
+
+  test('returns 200 with success: true', async () => {
+    const res = await request(app).post(BASE).send(payload());
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  test('data contains all required fields', async () => {
+    const res = await request(app).post(BASE).send(payload());
+    const { data } = res.body;
+    expect(data).toHaveProperty('tx_id');
+    expect(data).toHaveProperty('decision');
+    expect(data).toHaveProperty('risk_score');
+    expect(data).toHaveProperty('triggered_rules');
+    expect(data).toHaveProperty('score_breakdown');
+    expect(data).toHaveProperty('evaluation_time');
+    expect(data).toHaveProperty('is_alert_generated');
+  });
+
+  test('tx_id is a valid UUID', async () => {
+    const res = await request(app).post(BASE).send(payload());
+    expect(res.body.data.tx_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    );
+  });
+
+  test('decision is one of ALLOW, REVIEW, BLOCK', async () => {
+    const res = await request(app).post(BASE).send(payload());
+    expect(['ALLOW', 'REVIEW', 'BLOCK']).toContain(res.body.data.decision);
+  });
+
+  test('risk_score is a non-negative number', async () => {
+    const res = await request(app).post(BASE).send(payload());
+    expect(typeof res.body.data.risk_score).toBe('number');
+    expect(res.body.data.risk_score).toBeGreaterThanOrEqual(0);
+  });
+
+  test('triggered_rules is an array', async () => {
+    const res = await request(app).post(BASE).send(payload());
+    expect(Array.isArray(res.body.data.triggered_rules)).toBe(true);
+  });
+
+  test('score_breakdown is an array', async () => {
+    const res = await request(app).post(BASE).send(payload());
+    expect(Array.isArray(res.body.data.score_breakdown)).toBe(true);
+  });
+
+  test('evaluation_time is a valid ISO datetime string', async () => {
+    const res = await request(app).post(BASE).send(payload());
+    const d = new Date(res.body.data.evaluation_time);
+    expect(isNaN(d.getTime())).toBe(false);
+  });
+
+  test('is_alert_generated is a boolean', async () => {
+    const res = await request(app).post(BASE).send(payload());
+    expect(typeof res.body.data.is_alert_generated).toBe('boolean');
+  });
+});
+
+// ── Decision Correctness ───────────────────────────────────────────────────────
+
+describe('POST /api/transactions/evaluate — decision outcomes', () => {
+
+  test('high amount (₹100,000) produces BLOCK decision', async () => {
+    // Triggers "High Amount Block" (amount > 50000, weight 70) at minimum → BLOCK
+    const res = await request(app).post(BASE).send(payload({ amount: 100_000 }));
+    expect(res.body.data.decision).toBe('BLOCK');
+    expect(res.body.data.is_alert_generated).toBe(true);
+  });
+
+  test('high amount triggers at least one rule', async () => {
+    const res = await request(app).post(BASE).send(payload({ amount: 100_000 }));
+    expect(res.body.data.triggered_rules.length).toBeGreaterThan(0);
+  });
+
+  test('high amount score_breakdown entries match triggered_rules count', async () => {
+    const res = await request(app).post(BASE).send(payload({ amount: 100_000 }));
+    const { triggered_rules, score_breakdown } = res.body.data;
+    expect(score_breakdown.length).toBe(triggered_rules.length);
+  });
+
+  test('triggered rule entries have the correct shape', async () => {
+    const res = await request(app).post(BASE).send(payload({ amount: 100_000 }));
+    const rule = res.body.data.triggered_rules[0];
+    expect(rule).toHaveProperty('rule_id');
+    expect(rule).toHaveProperty('rule_name');
+    expect(rule).toHaveProperty('rule_type');
+    expect(rule).toHaveProperty('weight_applied');
+    expect(rule).toHaveProperty('reason');
+  });
+
+  test('small safe amount (₹100) during daytime produces ALLOW decision', async () => {
+    // Only "Safe Amount" (amount <= 5000, weight 10) may trigger → score ≤ 10 → ALLOW
+    const res = await request(app).post(BASE).send(payload({ amount: 100 }));
+    expect(res.body.data.decision).toBe('ALLOW');
+    expect(res.body.data.is_alert_generated).toBe(false);
+  });
+
+  test('each evaluation produces a unique tx_id', async () => {
+    const [a, b] = await Promise.all([
+      request(app).post(BASE).send(payload()),
+      request(app).post(BASE).send(payload()),
+    ]);
+    expect(a.body.data.tx_id).not.toBe(b.body.data.tx_id);
+  });
+
+  test('optional transaction_time is accepted and reflected in response', async () => {
+    const time = '2026-06-16T14:30:00.000Z';
+    const res = await request(app).post(BASE).send(payload({ transaction_time: time }));
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  test('omitting transaction_time defaults to current time', async () => {
+    const { transaction_time, ...noTime } = payload();
+    const res = await request(app).post(BASE).send(noTime);
+    expect(res.status).toBe(200);
+    const d = new Date(res.body.data.evaluation_time);
+    expect(isNaN(d.getTime())).toBe(false);
+  });
+});
+
+// ── Validation Errors ─────────────────────────────────────────────────────────
+
+describe('POST /api/transactions/evaluate — validation errors (400)', () => {
+
+  test('missing user_id → 400', async () => {
+    const { user_id, ...body } = payload();
+    const res = await request(app).post(BASE).send(body);
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  test('invalid user_id (not a UUID) → 400', async () => {
+    const res = await request(app).post(BASE).send(payload({ user_id: 'not-a-uuid' }));
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  test('missing amount → 400', async () => {
+    const { amount, ...body } = payload();
+    const res = await request(app).post(BASE).send(body);
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  test('zero amount → 400', async () => {
+    const res = await request(app).post(BASE).send(payload({ amount: 0 }));
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  test('negative amount → 400', async () => {
+    const res = await request(app).post(BASE).send(payload({ amount: -500 }));
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  test('missing location → 400', async () => {
+    const { location, ...body } = payload();
+    const res = await request(app).post(BASE).send(body);
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  test('empty location string → 400', async () => {
+    const res = await request(app).post(BASE).send(payload({ location: '' }));
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  test('missing device_id → 400', async () => {
+    const { device_id, ...body } = payload();
+    const res = await request(app).post(BASE).send(body);
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  test('invalid transaction_time (not ISO 8601) → 400', async () => {
+    const res = await request(app).post(BASE).send(payload({ transaction_time: '16-06-2026' }));
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  test('empty body → 400', async () => {
+    const res = await request(app).post(BASE).send({});
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  test('error response includes errors array with messages', async () => {
+    const res = await request(app).post(BASE).send({});
+    expect(Array.isArray(res.body.errors)).toBe(true);
+    expect(res.body.errors.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 79 integration tests across all three core API endpoints (closes #30)
- Also fixes a pre-existing backend bug discovered during testing

## Tests Added

| File | Tests | Coverage |
|------|-------|----------|
| `transaction.api.test.ts` | 27 | Response shape, BLOCK/ALLOW decisions, all validation errors |
| `rules.api.test.ts` | 29 | Full CRUD — create, read, update, toggle, delete, 409/400/404 cases |
| `results.api.test.ts` | 23 | List, pagination, decision filter, get by txId, ordering, 404 |

**Total: 215 tests passing (was 136)**

## Bug Fix

`weight_applied` was missing from the `rule_evaluation_trace` INSERT in `transaction.service.ts`. This caused every call to `POST /api/transactions/evaluate` to return a 500 error when any rule triggered. Fixed as part of this PR since the integration tests caught it immediately.

## Test Plan

- [ ] `cd backend && npm test` — all 215 tests pass
- [ ] `npm run dev` — backend starts and `/health` returns ok
- [ ] `POST /api/transactions/evaluate` with a valid payload — returns 200 with decision